### PR TITLE
Add toPython and toJava

### DIFF
--- a/codegeneration/CodeGenerator.js
+++ b/codegeneration/CodeGenerator.js
@@ -15,6 +15,8 @@ function Visitor() {
 Visitor.prototype = Object.create(ECMAScriptVisitor.prototype);
 Visitor.prototype.constructor = Visitor;
 
+Visitor.prototype.start = Visitor.prototype.visitExpressionSequence;
+
 Visitor.prototype.types = Object.freeze({
   STRING: 0, REGEX: 1,
   BOOL: 10,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0*/
 const antlr4 = require('antlr4');
 const ECMAScriptLexer = require('./lib/ECMAScriptLexer.js');
 const ECMAScriptParser = require('./lib/ECMAScriptParser.js');
@@ -10,29 +9,20 @@ const JavaGenerator = require('./codegeneration/JavaGenerator.js');
  * Compiles an ECMAScript string into another language.
  *
  * @param {String} input
- * @param {antlr4.tree.ParseTreeVisitor} generator
+ * @param {CodeGenerator} generator
+ * @returns {String}
  */
 const compileECMAScript = function(input, generator) {
-  // Create parse tree
   const chars = new antlr4.InputStream(input);
   const lexer = new ECMAScriptLexer.ECMAScriptLexer(chars);
   const tokens = new antlr4.CommonTokenStream(lexer);
   const parser = new ECMAScriptParser.ECMAScriptParser(tokens);
   parser.buildParseTrees = true;
   const tree = parser.expressionSequence();
-
-  // Print
-  // const listener = new ECMAScriptPrinter();
-  // const AST = listener.buildAST(tree, parser.ruleNames);
-  // console.log('ECMAScript AST----------------------');
-  // console.log(JSON.stringify(AST, null, 2));
-  // console.log('----------------------');
-
-  // Generate Code
-  return generator.visitExpressionSequence(tree);
+  return generator.start(tree);
 };
 
-const input = '[1, 2]';
-console.log(compileECMAScript(input, new JavaGenerator()));
-
-module.exports = compileECMAScript;
+module.exports = {
+  toJava: (input) => { return compileECMAScript(input, new JavaGenerator()); },
+  toPython: (input) => { return compileECMAScript(input, new Python3Generator()); }
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,13 +4,11 @@ const fs = require('fs');
 const chai = require('chai');
 const expect = chai.expect;
 
-const Python3Generator = require('../codegeneration/Python3Generator.js');
-const JavaGenerator = require('../codegeneration/JavaGenerator.js');
-const compileECMAScript = require('../');
+const { toJava, toPython } = require('../');
 
-const generators = {
-  java: new JavaGenerator(),
-  python: new Python3Generator()
+const compile = {
+  java: toJava,
+  python: toPython
 };
 
 // Need a way to have test pass while developing
@@ -32,14 +30,14 @@ const readJSON = (filename) => {
   return parseResult.value;
 };
 
-const runTest = (inputLang, outputLang, tests, generator) => {
+const runTest = (inputLang, outputLang, tests) => {
   describe(`${inputLang} ==> ${outputLang}`, () => {
     Object.keys(tests).forEach((key) => {
       describe(key, () => {
         tests[key].map((test) => {
           const skip = unsupported[outputLang].indexOf(key) !== -1;
           (skip ? xit : it)(test.description, () => {
-            expect(compileECMAScript(test[inputLang], generator)).to.equal(test[outputLang]);
+            expect(compile[outputLang](test[inputLang])).to.equal(test[outputLang]);
           });
         });
       });
@@ -48,7 +46,6 @@ const runTest = (inputLang, outputLang, tests, generator) => {
 };
 
 module.exports = {
-  generators: generators,
   readJSON: readJSON,
   runTest: runTest
 };

--- a/test/type-constructors.test.js
+++ b/test/type-constructors.test.js
@@ -1,4 +1,4 @@
-const { generators, readJSON, runTest } = require('./helpers');
+const { readJSON, runTest } = require('./helpers');
 
 const languages = ['java', 'python'];
 const inputLang = 'query';
@@ -6,14 +6,14 @@ const inputLang = 'query';
 describe('BSONConstructors', () => {
   const tests = readJSON('./bson-constructors.json').bsonTypes;
   languages.forEach((outputLang) => {
-    runTest(inputLang, outputLang, tests, generators[outputLang]);
+    runTest(inputLang, outputLang, tests);
   });
 });
 
 describe('Built-in Object Constructors', () => {
   const tests = readJSON('./built-in-types.json').types;
   languages.forEach((outputLang) => {
-    runTest(inputLang, outputLang, tests, generators[outputLang]);
+    runTest(inputLang, outputLang, tests);
   });
 });
 


### PR DESCRIPTION
Export language-specific functions so that package users don't have to construct their own generators. Will be much nicer to demo.