### PR TITLE
COMPASS-2624: simple C# generator

### DIFF
--- a/codegeneration/CSharpGenerator.js
+++ b/codegeneration/CSharpGenerator.js
@@ -1,0 +1,52 @@
+const CodeGenerator = require('./CodeGenerator.js');
+
+function Visitor() {
+  CodeGenerator.call(this);
+
+  return this;
+}
+
+Visitor.prototype = Object.create(CodeGenerator.prototype);
+Visitor.prototype.constructor = Visitor;
+
+// assign a string type to current ctx
+// get double quotes around the string
+Visitor.prototype.visitStringLiteral = function(ctx) {
+  ctx.type = this.types.STRING;
+  return this.doubleQuoteStringify(this.visitChildren(ctx));
+};
+
+// similar to java, we also want to ignore js's `new` expression, and c# always
+// needs it
+Visitor.prototype.visitNewExpression = function(ctx) {
+  const expr = this.visit(ctx.singleExpression());
+  ctx.type = ctx.singleExpression().type;
+  return expr;
+};
+
+/*  ************** built-in js identifiers **************** */
+
+// adjust the Number constructor;
+// returns new int(num)
+Visitor.prototype.visitNumberConstructorExpression = function(ctx) {
+  const argList = ctx.arguments().argumentList();
+
+  if (!argList || argList.singleExpression().length !== 1) {
+    return 'Error: Number requires one argument';
+  }
+
+  const arg = argList.singleExpression()[0];
+  const number = this.removeQuotes(this.visit(arg));
+
+  if (isNaN(parseInt(number, 10)) ||
+    ( arg.type !== this.types.STRING &&
+      arg.type !== this.types.DECIMAL &&
+      arg.type !== this.types.INTEGER)
+  ) {
+    return 'Error: Number requires a number or a string argument';
+  }
+
+  return `new int(${number})`;
+};
+
+module.exports = Visitor;

--- a/codegeneration/CSharpGenerator.js
+++ b/codegeneration/CSharpGenerator.js
@@ -51,10 +51,9 @@ Visitor.prototype.visitNumberConstructorExpression = function(ctx) {
   const arg = argList.singleExpression()[0];
   const number = this.removeQuotes(this.visit(arg));
 
-  if (isNaN(parseInt(number, 10)) ||
-    ( arg.type !== this.types.STRING &&
-      arg.type !== this.types.DECIMAL &&
-      arg.type !== this.types.INTEGER)
+  if (
+    (arg.type !== this.types.STRING && this.isNumericType(arg) === false)
+    || isNaN(Number(number))
   ) {
     return 'Error: Number requires a number or a string argument';
   }

--- a/codegeneration/CSharpGenerator.js
+++ b/codegeneration/CSharpGenerator.js
@@ -16,12 +16,25 @@ Visitor.prototype.visitStringLiteral = function(ctx) {
   return this.doubleQuoteStringify(this.visitChildren(ctx));
 };
 
+// there is no undefined in c#
+Visitor.prototype.visitUndefinedLiteral = function(ctx) {
+  ctx.type = this.types.UNDEFINED;
+  return 'null';
+};
+
 // similar to java, we also want to ignore js's `new` expression, and c# always
 // needs it
 Visitor.prototype.visitNewExpression = function(ctx) {
   const expr = this.visit(ctx.singleExpression());
   ctx.type = ctx.singleExpression().type;
   return expr;
+};
+
+// c# does not have octal numbers, so we need to convert it to reg integer
+// TODO: not sure if we should still set the type to OCTAL or INTEGER
+Visitor.prototype.visitOctalIntegerLiteral = function(ctx) {
+  ctx.type = this.types.OCTAL;
+  return parseInt(this.visitChildren(ctx), 10);
 };
 
 /*  ************** built-in js identifiers **************** */

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const ECMAScriptLexer = require('./lib/ECMAScriptLexer.js');
 const ECMAScriptParser = require('./lib/ECMAScriptParser.js');
 
 const Python3Generator = require('./codegeneration/Python3Generator.js');
+const CSharpGenerator = require('./codegeneration/CSharpGenerator.js');
 const JavaGenerator = require('./codegeneration/JavaGenerator.js');
 
 /**
@@ -25,5 +26,6 @@ const compileECMAScript = function(input, generator) {
 
 module.exports = {
   toJava: (input) => { return compileECMAScript(input, new JavaGenerator()); },
+  toCSharp: (input) => { return compileECMAScript(input, new CSharpGenerator()); },
   toPython: (input) => { return compileECMAScript(input, new Python3Generator()); }
 };

--- a/test/built-in-types.json
+++ b/test/built-in-types.json
@@ -5,20 +5,36 @@
     "csharp"
   ],
   "types": {
+    "math": [
+      {
+        "description": "simple addition",
+        "query": "2+5",
+        "python": "2+5",
+        "java": "2+5",
+        "csharp": "2+5"
+      },
+      {
+        "description": "multiplication and division",
+        "query": "2+(4*36)/3",
+        "python": "2+(4*36)/3",
+        "java": "2+(4*36)/3",
+        "csharp": "2+(4*36)/3"
+      }
+    ],
     "Number": [
       {
         "description": "Number with number arg",
         "query": "new Number(2)",
         "python": "int(2)",
         "java": "new java.lang.Integer(2)",
-        "csharp": ""
+        "csharp": "new int(2)"
       },
       {
         "description": "Number with valid string arg",
         "query": "new Number('2')",
         "python": "int(2)",
         "java": "new java.lang.Integer(\"2\")",
-        "csharp": ""
+        "csharp": "new int(2)"
       }
     ],
     "literals": [
@@ -41,14 +57,14 @@
         "query": "0X123ABC",
         "python": "0X123ABC",
         "java": "0X123ABC",
-        "csharp": ""
+        "csharp": "0X123ABC"
       },
       {
         "description": "Hex number lower",
         "query": "0x123abc",
         "python": "0x123abc",
         "java": "0x123abc",
-        "csharp": ""
+        "csharp": "0x123abc"
       },
       {
         "description": "Octal 0-prefix number",
@@ -83,42 +99,42 @@
         "query": "'string'",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": ""
+        "csharp": "@\"string\""
       },
       {
         "description": "Double-quote string",
         "query": "\"string\"",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": ""
+        "csharp": "@\"string\""
       },
       {
         "description": "null",
         "query": "null",
         "python": "None",
         "java": "null",
-        "csharp": ""
+        "csharp": "null"
       },
       {
         "description": "undefined",
         "query": "undefined",
         "python": "None",
         "java": "null",
-        "csharp": ""
+        "csharp": "null"
       },
       {
         "description": "true",
         "query": "true",
         "python": "True",
         "java": "true",
-        "csharp": ""
+        "csharp": "true"
       },
       {
         "description": "false",
         "query": "false",
         "python": "False",
         "java": "false",
-        "csharp": ""
+        "csharp": "false"
       }
     ],
     "Date": [

--- a/test/built-in-types.json
+++ b/test/built-in-types.json
@@ -71,42 +71,42 @@
         "query": "01234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": ""
+        "csharp": "1234567"
       },
       {
         "description": "Octal 00-prefix number",
         "query": "001234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": ""
+        "csharp": "1234567"
       },
       {
         "description": "Octal 0o-prefix number",
         "query": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": ""
+        "csharp": "0"
       },
       {
         "description": "Octal 0O-prefix number",
         "query": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": ""
+        "csharp": "0"
       },
       {
         "description": "Single-quote string",
         "query": "'string'",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": "@\"string\""
+        "csharp": "\"string\""
       },
       {
         "description": "Double-quote string",
         "query": "\"string\"",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": "@\"string\""
+        "csharp": "\"string\""
       },
       {
         "description": "null",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,11 +4,12 @@ const fs = require('fs');
 const chai = require('chai');
 const expect = chai.expect;
 
-const { toJava, toPython } = require('../');
+const { toJava, toPython, toCSharp } = require('../');
 
 const compile = {
   java: toJava,
-  python: toPython
+  python: toPython,
+  csharp: toCSharp
 };
 
 // Need a way to have test pass while developing
@@ -18,6 +19,9 @@ const unsupported = {
   ],
   python: [
     'RegExp', 'BSONRegExp', 'DBRef', 'Decimal128', 'Timestamp', 'literals', 'ArrayElision'
+  ],
+  csharp: [
+    'RegExp', 'BSONRegExp', 'DBRef', 'Decimal128', 'Code', 'ObjectId', 'Binary', 'Double', 'Long', 'Decimal128', 'MinKey/MaxKey', 'Timestamp', 'Document', 'Array', 'ArrayElision', 'Symbol', 'literals', 'Date', 'DateNow', 'RegExp'
   ]
 };
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,7 +21,7 @@ const unsupported = {
     'RegExp', 'BSONRegExp', 'DBRef', 'Decimal128', 'Timestamp', 'literals', 'ArrayElision'
   ],
   csharp: [
-    'RegExp', 'BSONRegExp', 'DBRef', 'Decimal128', 'Code', 'ObjectId', 'Binary', 'Double', 'Long', 'Decimal128', 'MinKey/MaxKey', 'Timestamp', 'Document', 'Array', 'ArrayElision', 'Symbol', 'literals', 'Date', 'DateNow', 'RegExp'
+    'RegExp', 'BSONRegExp', 'DBRef', 'Decimal128', 'Code', 'ObjectId', 'Binary', 'Double', 'Long', 'Decimal128', 'MinKey/MaxKey', 'Timestamp', 'Document', 'Array', 'ArrayElision', 'Symbol', 'Date', 'DateNow', 'RegExp'
   ]
 };
 

--- a/test/type-constructors.test.js
+++ b/test/type-constructors.test.js
@@ -1,6 +1,6 @@
 const { readJSON, runTest } = require('./helpers');
 
-const languages = ['java', 'python'];
+const languages = ['java', 'python', 'csharp'];
 const inputLang = 'query';
 
 describe('BSONConstructors', () => {


### PR DESCRIPTION
This just sets up a c-sharp generator to work with the module and hooks up the tests / unsupported types to `test/helpers.js` and `type-constructors.test.js`.

With this PR, the following tests are working:
- [x] Arithmetics
- [x] Number
- [x] literals

As I was working on this, I had a question about Octals. It seems that ecmascript doesn't allow for [octals anymore](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) (scroll down a bit, can't get a link to that section). C# also doesn't have octals. If someone does end up typing `01234567` as an octal, is that technically just `1234567` in integer format? I am just `parseInt()`ing that at the moment, but probably need to change it maybe?