### PR TITLE
make dates work in csharp

### DIFF
--- a/codegeneration/CSharpGenerator.js
+++ b/codegeneration/CSharpGenerator.js
@@ -62,6 +62,36 @@ Visitor.prototype.visitNumberConstructorExpression = function(ctx) {
   return `new int(${number})`;
 };
 
+Visitor.prototype.visitDateConstructorExpression = function(ctx) {
+  const args = ctx.arguments();
+  if (!args.argumentList()) return 'DateTime.Now';
+
+  let dateStr;
+  try {
+    const epoch = this.executeJavascript(ctx.getText());
+
+    dateStr = [
+      epoch.getUTCFullYear(),
+      (epoch.getUTCMonth() + 1),
+      epoch.getUTCDate(),
+      epoch.getUTCHours(),
+      epoch.getUTCMinutes(),
+      epoch.getUTCSeconds()
+    ].join(', ');
+  } catch (error) {
+    return error.message;
+  }
+
+  return `new DateTime(${dateStr})`;
+};
+
+
+// csharp doesn't allow for current time to be set on new instance, so it's
+// just DateTime.Now
+Visitor.prototype.visitDateNowConstructorExpression = function() {
+  return 'DateTime.Now';
+};
+
 /**
  * Expects two strings as arguments, the second must be valid flag
  *

--- a/test/built-in-types.json
+++ b/test/built-in-types.json
@@ -143,35 +143,35 @@
         "query": "new Date('December 17, 1995 03:24:00Z')",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819170640000)",
-        "csharp": ""
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
       },
       {
         "description": "new Date with UTC number",
         "query": "new Date(819167040000)",
         "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819167040000)",
-        "csharp": ""
+        "csharp": "new DateTime(1995, 12, 17, 2, 24, 0)"
       },
       {
         "description": "Current date",
         "query": "new Date()",
         "python": "datetime.datetime.utcnow().date()",
         "java": "new java.util.Date()",
-        "csharp": ""
+        "csharp": "DateTime.Now"
       },
       {
         "description": "Date from year, month and day",
         "query": "new Date(1995, 11, 17)",
         "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819158400000)",
-        "csharp": ""
+        "csharp": "new DateTime(1995, 12, 17, 0, 0, 0)"
       },
       {
         "description": "Date from year, month, day, hour, min and sec",
         "query": "new Date(1995, 11, 17, 3, 24, 0)",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819170640000)",
-        "csharp": ""
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
       }
     ],
     "DateNow": [
@@ -180,7 +180,7 @@
         "query": "Date.now()",
         "python": "datetime.datetime.utcnow()",
         "java": "new java.util.Date()",
-        "csharp": ""
+        "csharp": "DateTime.Now"
       }
     ],
     "RegExp": [

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -16,7 +16,7 @@ const compile = {
 const unsupported = {
   java: ['Decimal128'],
   python: ['Decimal128'],
-  csharp: ['RegExp', 'DBRef', 'Decimal128', 'Date', 'DateNow']
+  csharp: ['RegExp', 'DBRef', 'Decimal128']
 };
 
 const readJSON = (filename) => {


### PR DESCRIPTION
C# does the same thing as python -- needs date numbers as separate arguments. 

The only quirk is that the `now` constructor doesn't need the `new` word. not quite sure why, but tried it out in [C# playground](https://dotnetfiddle.net/) and it works as just `DateTime.Now`.