### PR TITLE
regex output for c#

### DIFF
--- a/test/json/success/js-constructors.json
+++ b/test/json/success/js-constructors.json
@@ -175,84 +175,84 @@
         "query": "RegExp('')",
         "python": "re.compile(r\"(?:)\")",
         "java": "Pattern.compile(\"(?:)\")",
-        "csharp": ""
+        "csharp": "new Regex(\"\")"
       },
       {
         "description": "RegExp without options",
         "query": "RegExp('abc')",
         "python": "re.compile(r\"abc\")",
         "java": "Pattern.compile(\"abc\")",
-        "csharp": ""
+        "csharp": "new Regex(\"abc\")"
       },
       {
         "description": "regex object with im flags as args",
         "query": "new RegExp('ab+c', 'im')",
         "python": "re.compile(r\"ab+c(?im)\")",
         "java": "Pattern.compile(\"ab+c(?im)\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab+c\", RegexOptions.IgnoreCase | RegexOptions.Multiline)"
       },
       {
         "description": "regex object with ig flags as args",
         "query": "new RegExp('ab+c', 'ig')",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab+c\", RegexOptions.IgnoreCase)"
       },
       {
         "description": "regex object with forward slash",
         "query": "new RegExp('ab/cd')",
         "python": "re.compile(r\"ab\\/cd\")",
         "java": "Pattern.compile(\"ab\\/cd\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab/cd\")"
       },
       {
         "description": "regex object with escaped double quote",
         "query": "new RegExp('ab\\\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab\\\"ab\")"
       },
       {
         "description": "regex object with nonescaped double quote",
         "query": "new RegExp('ab\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab\\\"ab\")"
       },
       {
         "description": "regex object with escaped single quote",
         "query": "new RegExp('ab\\'ab')",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab'ab\")"
       },
       {
         "description": "regex object with nonescaped single quote",
         "query": "new RegExp(\"ab'ab\")",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab'ab\")"
       },
       {
         "description": "regex object with newline",
         "query": "new RegExp(\"\\\\n\")",
         "python": "re.compile(r\"\\\\n\")",
         "java": "Pattern.compile(\"\\\\n\")",
-        "csharp": ""
+        "csharp": "new Regex(\"\\\\n\")"
       },
       {
         "description": "regex literal with ig flags",
         "query": "/ab+c/ig",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab+c\", RegexOptions.IgnoreCase)"
       },
       {
         "description": "regex object with regex literal arg",
         "query": "new RegExp(/ab+c/, 'i')",
         "python": "re.compile(r\"ab+c(?i)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": ""
+        "csharp": "new Regex(\"ab+c\", RegexOptions.IgnoreCase)"
       }
     ]
   }

--- a/test/json/success/js-constructors.json
+++ b/test/json/success/js-constructors.json
@@ -175,7 +175,7 @@
         "query": "RegExp('')",
         "python": "re.compile(r\"(?:)\")",
         "java": "Pattern.compile(\"(?:)\")",
-        "csharp": "new Regex(\"\")"
+        "csharp": "new Regex(\"(?:)\")"
       },
       {
         "description": "RegExp without options",
@@ -203,7 +203,7 @@
         "query": "new RegExp('ab/cd')",
         "python": "re.compile(r\"ab\\/cd\")",
         "java": "Pattern.compile(\"ab\\/cd\")",
-        "csharp": "new Regex(\"ab/cd\")"
+        "csharp": "new Regex(\"ab\\/cd\")"
       },
       {
         "description": "regex object with escaped double quote",
@@ -238,7 +238,7 @@
         "query": "new RegExp(\"\\\\n\")",
         "python": "re.compile(r\"\\\\n\")",
         "java": "Pattern.compile(\"\\\\n\")",
-        "csharp": "new Regex(\"\\\\n\")"
+        "csharp": "new Regex(\"\\n\")"
       },
       {
         "description": "regex literal with ig flags",


### PR DESCRIPTION
make regex get converted to c###### 

- [x] tests with appropriate results in c#
- [x] visitors to adjust the input to make the right output


I am currently using a few things to make sure this c# thing is working:
- [docs on regex options in c#](https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regexoptions(v=vs.110).aspx)
- [docs on regex itself](https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex(v=vs.110).aspx)
- [regex playground for .net](http://regexstorm.net/tester)
- [playground for .net itself](https://dotnetfiddle.net/)