### PR TITLE
Remove all visit methods from JavaGenerator

### DIFF
--- a/codegeneration/CodeGenerator.js
+++ b/codegeneration/CodeGenerator.js
@@ -234,6 +234,20 @@ Visitor.prototype.visitGetAttributeExpression = function(ctx) {
   return `${lhs}.${rhs}`;
 };
 
+Visitor.prototype.visitNewExpression = function(ctx) {
+  if ('emitNew' in this) {
+    return this.emitNew(ctx);
+  }
+  return this.visitChildren(ctx);
+};
+
+Visitor.prototype.visitRegularExpressionLiteral = function(ctx) {
+  if ('emitRegExp' in this) {
+    return this.emitRegExp(ctx);
+  }
+  return this.visitChildren(ctx);
+};
+
 
 /**
  * Visit a leaf node and return a string.

--- a/codegeneration/JavaGenerator.js
+++ b/codegeneration/JavaGenerator.js
@@ -45,7 +45,7 @@ Visitor.prototype.binary_subTypes = {
  * @param {NewExpressionContext} ctx
  * @return {String}
  */
-Visitor.prototype.visitNewExpression = function(ctx) {
+Visitor.prototype.emitNew = function(ctx) {
   const expr = this.visit(ctx.singleExpression());
   ctx.type = ctx.singleExpression().type;
   return expr;
@@ -60,7 +60,7 @@ Visitor.prototype.visitNewExpression = function(ctx) {
  * @param {FuncCallExpressionContext} ctx
  * @return {String}
  */
-Visitor.prototype.visitRegularExpressionLiteral = function(ctx) {
+Visitor.prototype.emitRegExp = function(ctx) {
   ctx.type = this.Types.Regex;
   let pattern;
   let flags;
@@ -80,8 +80,6 @@ Visitor.prototype.visitRegularExpressionLiteral = function(ctx) {
 
   return `Pattern.compile(${doubleQuoteStringify(escaped + javaflags)})`;
 };
-
-/*  ************** Emit Helpers **************** */
 
 /**
  * Special cased because different target languages need different info out
@@ -142,8 +140,6 @@ Visitor.prototype.emitBSONRegExp = function(ctx) {
   }
   return `new BsonRegularExpression(${args[0]})`;
 };
-
-Visitor.prototype.emitRegExp = Visitor.prototype.visitRegularExpressionLiteral;
 
 /**
  * The arguments to Code can be either a string or actual javascript code.


### PR DESCRIPTION
This is in preparation for accepting multiple input languages. None of the target-language-specific generators (i.e. JavaGenerator.js, Python3Generator.js, etc) should have any of their own `visitX` methods since that is input-language PST specific. Everything input-language specific should go in CodeGenerator.py.