### PR TITLE
Update package API and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,23 @@
 # BSON-Compilers
 Transpilers for building BSON documents in any language.
+## Authors
+Anna Herlihy (herlihyap@gmail.com)
 
-* https://github.com/antlr/antlr4/blob/master/doc/javascript-target.md
-* https://github.com/antlr/grammars-v4
+Alena Khineika (alena.khineika@mongodb.com)
 
-## Environment Setup via Homebrew
-
-* `$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-* `$ brew install nvm`
-* `$ nvm install 8.2.1 && nvm alias default 8.2.1`
-
-## ANTLR4 Setup
-
-* `$ brew cask install java`
-* `$ cd /usr/local/lib`
-* `$ curl -O http://www.antlr.org/download/antlr-4.7.1-complete.jar`
-* `$ export CLASSPATH=".:/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH"`
-* `$ alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH" org.antlr.v4.Tool'`
-* `$ alias grun='java org.antlr.v4.gui.TestRig'`
-
-## Testing the installation
-
-* `$ java org.antlr.v4.Tool`
-
-## Generating Lexer, Parser and Listener
-
-* `$ antlr4 <FileName>.g4`
+Irina Shestak (shestak.irina@gmail.com)
 
 ## App Start
 
-* `$ npm run compile && npm start`
+* `$ npm run compile`
+
+## Usage
+```
+const compiler = require('bson-compilers');
+
+const input = 'javascript';
+const output = 'java';
+compiler[input][output]("some code in js to compile to java");
+// or
+compiler.javascript.java("some code in js to compile to java");
+```

--- a/codegeneration/java/Generator.js
+++ b/codegeneration/java/Generator.js
@@ -150,7 +150,7 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
    * @param {FuncCallExpressionContext} ctx
    * @return {String}
    */
-  emitCode(ctx) {
+  emitCodeFromJS(ctx) {
     ctx.type = this.Types.Code;
     const argList = ctx.arguments().argumentList();
     if (!argList ||

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -149,14 +149,12 @@ class Visitor extends ECMAScriptVisitor {
       lhsType = this.Types[lhsType];
     }
 
-    // Special case types
+    // Special case
     if (`emit${lhsType.id}` in this) {
       return this[`emit${lhsType.id}`](ctx);
     }
 
-    const expectedArgs = lhsType.args;
-    let rhs = this.checkArguments(expectedArgs, ctx.arguments().argumentList());
-
+    // Check if callable
     ctx.type = lhsType.type;
     if (!lhsType.callable) {
       throw new SemanticTypeError({
@@ -164,7 +162,11 @@ class Visitor extends ECMAScriptVisitor {
       });
     }
 
-    // TODO: don't need for other languages
+    // Check arguments
+    const expectedArgs = lhsType.args;
+    let rhs = this.checkArguments(expectedArgs, ctx.arguments().argumentList());
+
+    // Add new if needed
     const newStr = lhsType.callable === this.SYMBOL_TYPE.CONSTRUCTOR ? this.new : '';
     if (lhsType.argsTemplate) {
       let l = lhs;

--- a/codegeneration/shell/Visitor.js
+++ b/codegeneration/shell/Visitor.js
@@ -12,57 +12,54 @@ const {
  *
  * @returns {object}
  */
-function Visitor() {
-  JavascriptVisitor.call(this);
-  return this;
-}
-Visitor.prototype = Object.create(JavascriptVisitor.prototype);
-Visitor.prototype.constructor = Visitor;
-Visitor.prototype.new = '';
+class Visitor extends JavascriptVisitor {
+  constructor() {
+    super();
+    this.new = '';
+  }
 
-Visitor.prototype.start = Visitor.prototype.visitExpressionSequence;
-
-Visitor.prototype.executeJavascript = function(input) {
-  const sandbox = {
-    RegExp: RegExp,
-    DBRef: bson.DBRef,
-    Map: bson.Map,
-    MaxKey: bson.MaxKey,
-    MinKey: bson.MinKey,
-    ObjectId: bson.ObjectID,
-    Symbol: bson.Symbol,
-    Timestamp: bson.Timestamp,
-    Code: function(c, s) {
-      return new bson.Code(c, s);
-    },
-    NumberDecimal: function(s) {
-      return bson.Decimal128.fromString(s);
-    },
-    NumberInt: function(s) {
-      return parseInt(s, 10);
-    },
-    NumberLong: function(v) {
-      return bson.Long.fromNumber(v);
-    },
-    ISODate: function(s) {
-      return new Date(s);
-    },
-    Date: function(s) {
-      const args = Array.from(arguments);
-
-      if (args.length === 1) {
+  executeJavascript(input) {
+    const sandbox = {
+      RegExp: RegExp,
+      DBRef: bson.DBRef,
+      Map: bson.Map,
+      MaxKey: bson.MaxKey,
+      MinKey: bson.MinKey,
+      ObjectId: bson.ObjectID,
+      Symbol: bson.Symbol,
+      Timestamp: bson.Timestamp,
+      Code: function(c, s) {
+        return new bson.Code(c, s);
+      },
+      NumberDecimal: function(s) {
+        return bson.Decimal128.fromString(s);
+      },
+      NumberInt: function(s) {
+        return parseInt(s, 10);
+      },
+      NumberLong: function(v) {
+        return bson.Long.fromNumber(v);
+      },
+      ISODate: function(s) {
         return new Date(s);
-      }
+      },
+      Date: function(s) {
+        const args = Array.from(arguments);
 
-      return new Date(Date.UTC(...args));
-    },
-    Buffer: Buffer,
-    __result: {}
-  };
-  const ctx = new Context(sandbox);
-  const res = ctx.evaluate('__result = ' + input);
-  ctx.destroy();
-  return res;
-};
+        if (args.length === 1) {
+          return new Date(s);
+        }
+
+        return new Date(Date.UTC(...args));
+      },
+      Buffer: Buffer,
+      __result: {}
+    };
+    const ctx = new Context(sandbox);
+    const res = ctx.evaluate('__result = ' + input);
+    ctx.destroy();
+    return res;
+  }
+}
 
 module.exports = Visitor;

--- a/index.js
+++ b/index.js
@@ -54,25 +54,22 @@ const getCompiler = (inputLang, outputLang) => {
   return generator;
 };
 
-const toJava = () => {
+const make = (inputLang, outputLang) => {
+  const comp = getCompiler(inputLang, outputLang);
   return (input) => {
-    return compile(input, getCompiler('javascript', 'java'));
+    return compile(input, comp);
   };
 };
-
-const toCSharp = () => {
-  return (input) => {
-    return compile(input, getCompiler('javascript', 'csharp'));
-  };
-};
-
-const toPython = () => {
-  return (input) => {
-    return compile(input, getCompiler('javascript', 'python'));
-  };
-};
-
 
 module.exports = {
-  toJava: toJava(), toCSharp: toCSharp(), toPython: toPython()
+  javascript: {
+    java: make('javascript', 'java')
+    // python: make('javascript', 'python'),
+    // csharp: make('javascript', 'csharp')
+  },
+  shell: {
+    java: make('shell', 'java')
+    // python: make('shell', 'python'),
+    // csharp: make('shell', 'csharp')
+  }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "productName": "BSON Compilers",
   "description": "Source to source compilers using ANTLR",
   "contributors": [
-    "Anna Herlihy <anna@mongodb.com>",
+    "Anna Herlihy <herlihyap@gmail.com>",
     "Alena Khineika <alena.khineika@mongodb.com>",
     "Irina Shestak <irina.shestak@mongodb.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/bson-compilers",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "apiVersion": "0.0.1",
   "productName": "BSON Compilers",
   "description": "Source to source compilers using ANTLR",

--- a/symbols/javascript/symbols.yaml
+++ b/symbols/javascript/symbols.yaml
@@ -1,6 +1,6 @@
 BsonSymbols:
     Code: &CodeSymbol
-        id: "Code"
+        id: "CodeFromJS"
         callable: *constructor
         args:
             - [ *StringType ]

--- a/symbols/shell/types.yaml
+++ b/symbols/shell/types.yaml
@@ -3,11 +3,7 @@ BsonTypes:
         <<: *__type
         id: "Code"
         type: *ObjectType
-        attr:
-            toJSON:
-                <<: *__func
-                id: "CodetoJSON" # Needs emit method
-                type: *ObjectType
+        attr: {}
         template: *CodeTypeTemplate
     ObjectId: &ObjectIdType
         <<: *__type

--- a/test/code-generation.test.js
+++ b/test/code-generation.test.js
@@ -2,8 +2,8 @@ const { readJSON, runTest } = require('./helpers');
 const fs = require('fs');
 const path = require('path');
 
-const languages = ['java', 'python', 'csharp'];
-const inputLang = 'query';
+const outputLanguages = ['java', 'python', 'csharp'];
+const inputLanguages = ['javascript'];
 
 describe('Test', () => {
   const pSuccess = path.join(__dirname, 'json', 'success');
@@ -16,8 +16,10 @@ describe('Test', () => {
     const tests = readJSON(path.join(pSuccess, file)).tests;
     const testname = file.replace('.json', '');
 
-    languages.forEach((outputLang) => {
-      runTest('success', testname, inputLang, outputLang, tests);
+    inputLanguages.forEach((inputLang) => {
+      outputLanguages.forEach((outputLang) => {
+        runTest('success', testname, inputLang, outputLang, tests);
+      });
     });
   });
 
@@ -25,8 +27,10 @@ describe('Test', () => {
     const tests = readJSON(path.join(pError, file)).tests;
     const testname = file.replace('.json', '');
 
-    languages.forEach((outputLang) => {
-      runTest('error', testname, inputLang, outputLang, tests);
+    inputLanguages.forEach((inputLang) => {
+      outputLanguages.forEach((outputLang) => {
+        runTest('error', testname, inputLang, outputLang, tests);
+      });
     });
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,13 +3,7 @@ const fs = require('fs');
 const chai = require('chai');
 const expect = chai.expect;
 
-const { toJava, toPython, toCSharp } = require('../');
-
-const compile = {
-  java: toJava,
-  python: toPython,
-  csharp: toCSharp
-};
+const compiler = require('../');
 
 // Need a way to have test pass while developing
 const unsupported = {
@@ -39,18 +33,18 @@ const unsupported = {
 
 const checkResults = {
   success: function(inputLang, outputLang, test) {
-    expect(compile[outputLang].bind(this, test[inputLang])).to.not.throw();
-    expect(compile[outputLang](test[inputLang])).to.equal(test[outputLang]);
+    expect(compiler[inputLang][outputLang].bind(this, test[inputLang])).to.not.throw();
+    expect(compiler[inputLang][outputLang](test[inputLang])).to.equal(test[outputLang]);
   },
 
   error: function(inputLang, outputLang, test) {
     try {
-      compile[outputLang](test[inputLang]);
+      compiler[outputLang](test[inputLang]);
     } catch (error) {
       expect(error.code).to.equal(test.errorCode);
     }
 
-    expect(compile[outputLang].bind(this, test[inputLang])).to.throw();
+    expect(compiler[inputLang][outputLang].bind(this, test[inputLang])).to.throw();
   }
 };
 

--- a/test/json/success/bson-constructors.json
+++ b/test/json/success/bson-constructors.json
@@ -3,35 +3,35 @@
     "Code": [
       {
         "description": "new Code with string arg",
-        "query": "new Code('some code')",
+        "javascript": "new Code('some code')",
         "python": "Code('some code')",
         "java": "new Code(\"some code\")",
         "csharp": "new BsonJavaScript(@\"some code\")"
       },
       {
         "description": "Code with string code",
-        "query": "Code('some code')",
+        "javascript": "Code('some code')",
         "python": "Code('some code')",
         "java": "new Code(\"some code\")",
         "csharp": "new BsonJavaScript(@\"some code\")"
       },
       {
         "description": "Code with string code and object scope",
-        "query": "Code('string', {x: 1})",
+        "javascript": "Code('string', {x: 1})",
         "python": "Code('string', {'x': 1})",
         "java": "new CodeWithScope(\"string\", new Document().append(\"x\", 1))",
         "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", 1))"
       },
       {
         "description": "Code with function code",
-        "query": "Code(function(test) { console.log(test); })",
+        "javascript": "Code(function(test) { console.log(test); })",
         "python": "Code('function(test){console.log(test);}')",
         "java": "new Code(\"function(test){console.log(test);}\")",
         "csharp": "new BsonJavaScript(@\"function(test){console.log(test);}\")"
       },
       {
         "description": "Code with where code",
-        "query": "new Code('this.a > i', { i: 1 })",
+        "javascript": "new Code('this.a > i', { i: 1 })",
         "python": "Code('this.a > i', {'i': 1})",
         "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", 1))",
         "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", 1))"
@@ -40,21 +40,21 @@
     "ObjectId": [
       {
         "description": "ObjectId with no arg",
-        "query": "ObjectId()",
+        "javascript": "ObjectId()",
         "python": "ObjectId()",
         "java": "new ObjectId()",
         "csharp": "new BsonObjectId()"
       },
       {
         "description": "new ObjectId with no arg",
-        "query": "new ObjectId()",
+        "javascript": "new ObjectId()",
         "python": "ObjectId()",
         "java": "new ObjectId()",
         "csharp": "new BsonObjectId()"
       },
       {
         "description": "ObjectId with hex string arg",
-        "query": "ObjectId('5a7382114ec1f67ae445f778')",
+        "javascript": "ObjectId('5a7382114ec1f67ae445f778')",
         "python": "ObjectId('5a7382114ec1f67ae445f778')",
         "java": "new ObjectId(\"5a7382114ec1f67ae445f778\")",
         "csharp": "new BsonObjectId(\"5a7382114ec1f67ae445f778\")"
@@ -63,35 +63,35 @@
     "Binary": [
       {
         "description": "Binary with ascii buffer arg",
-        "query": "Binary(Buffer.from('a string'))",
+        "javascript": "Binary(Buffer.from('a string'))",
         "python": "Binary(bytes('a string', 'utf-8'))",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\"))",
         "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"))"
       },
       {
         "description": "new Binary with (ascii buffer, UUID subtype enum) args",
-        "query": "new Binary(Buffer.from(\"a string\"), Binary.SUBTYPE_UUID)",
+        "javascript": "new Binary(Buffer.from(\"a string\"), Binary.SUBTYPE_UUID)",
         "python": "Binary(bytes('a string', 'utf-8'), bson.binary.UUID_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.UUID, \"a string\".getBytes(\"UTF-8\"))",
         "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.UuidStandard)"
       },
       {
         "description": "Binary with (ascii buffer, number) args",
-        "query": "Binary(Buffer.from('a string'), '1')",
+        "javascript": "Binary(Buffer.from('a string'), '1')",
         "python": "Binary(bytes('a string', 'utf-8'), bson.binary.FUNCTION_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"a string\".getBytes(\"UTF-8\"))",
         "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.Function)"
       },
       {
         "description": "Binary with string args",
-        "query": "Binary('a string')",
+        "javascript": "Binary('a string')",
         "python": "Binary(bytes('a string', 'utf-8'))",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\"))",
         "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"))"
       },
       {
         "description": "Binary with (string, string) args",
-        "query": "Binary('a string', '1')",
+        "javascript": "Binary('a string', '1')",
         "python": "Binary(bytes('a string', 'utf-8'), bson.binary.FUNCTION_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"a string\".getBytes(\"UTF-8\"))",
         "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.Function)"
@@ -100,14 +100,14 @@
     "DBRef": [
       {
         "description": "new DBRef with (string, ObjectID) args",
-        "query": "new DBRef('coll', new ObjectId())",
+        "javascript": "new DBRef('coll', new ObjectId())",
         "python": "DBRef('coll', ObjectId())",
         "java": "new DBRef(\"coll\", new ObjectId())",
         "csharp": "DBRef(\"coll\", new BsonObjectId())"
       },
       {
         "description": "new DBRef with (string, ObjectId, string) args",
-        "query": "new DBRef('coll', ObjectId(), 'db')",
+        "javascript": "new DBRef('coll', ObjectId(), 'db')",
         "python": "DBRef('coll', ObjectId(), 'db')",
         "java": "new DBRef(\"coll\", new ObjectId(), \"db\")",
         "csharp": "DBRef(\"coll\", new BsonObjectId(), \"db\")"
@@ -116,14 +116,14 @@
     "Int32": [
       {
         "description": "Int32 with number arg",
-        "query": "Int32(3)",
+        "javascript": "Int32(3)",
         "python": "int(3)",
         "java": "new java.lang.Integer(3)",
         "csharp": ""
       },
       {
         "description": "Int32 with valid string arg",
-        "query": "Int32('3')",
+        "javascript": "Int32('3')",
         "python": "int(3)",
         "java": "new java.lang.Integer(\"3\")",
         "csharp": ""
@@ -132,21 +132,21 @@
     "Double": [
       {
         "description": "Double with number arg",
-        "query": "Double(3)",
+        "javascript": "Double(3)",
         "python": "float(3)",
         "java": "new java.lang.Double(3)",
         "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))"
       },
       {
         "description": "new Double with number arg",
-        "query": "new Double(3)",
+        "javascript": "new Double(3)",
         "python": "float(3)",
         "java": "new java.lang.Double(3)",
         "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))"
       },
       {
         "description": "Double with valid string arg",
-        "query": "Double('3')",
+        "javascript": "Double('3')",
         "python": "float(3)",
         "java": "new java.lang.Double(\"3\")",
         "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))"
@@ -155,7 +155,7 @@
     "Long": [
       {
         "description": "Long with two number args",
-        "query": "new Long(-1, 2147483647)",
+        "javascript": "new Long(-1, 2147483647)",
         "python": "Int64(9223372036854775807)",
         "java": "new java.lang.Long(\"9223372036854775807\")",
         "csharp": "new BsonInt64(Convert.ToInt32(9223372036854775807))"
@@ -164,7 +164,7 @@
     "Decimal128": [
       {
         "description": "new Decimal128 with string arg",
-        "query": "new Decimal128(Buffer.from('5'))",
+        "javascript": "new Decimal128(Buffer.from('5'))",
         "python": "Decimal128(Decimal('5'))",
         "java": "Decimal128.parse(\"5.3E-6175\")",
         "csharp": "new BsonString(\"5\")"
@@ -173,28 +173,28 @@
     "MinKey/MaxKey": [
       {
         "description": "MinKey",
-        "query": "MinKey()",
+        "javascript": "MinKey()",
         "python": "MinKey()",
         "java": "new MinKey()",
         "csharp": "BsonMinKey.Value"
       },
       {
         "description": "new MinKey",
-        "query": "new MinKey()",
+        "javascript": "new MinKey()",
         "python": "MinKey()",
         "java": "new MinKey()",
         "csharp": "BsonMinKey.Value"
       },
       {
         "description": "maxKey",
-        "query": "MaxKey()",
+        "javascript": "MaxKey()",
         "python": "MaxKey()",
         "java": "new MaxKey()",
         "csharp": "BsonMaxKey.Value"
       },
       {
         "description": "new MaxKey",
-        "query": "new MaxKey()",
+        "javascript": "new MaxKey()",
         "python": "MaxKey()",
         "java": "new MaxKey()",
         "csharp": "BsonMaxKey.Value"
@@ -203,14 +203,14 @@
     "BSONRegExp": [
       {
         "description": "new BSONRegExp with string arg",
-        "query": "new BSONRegExp('^[a-z0-9_-]{3,16}$')",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$')",
         "python": "RegExp('^[a-z0-9_-]{3,16}$')",
         "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\")",
         "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\")"
       },
       {
         "description": "new BSONRegExp with string arg and flags",
-        "query": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
         "python": "RegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
         "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\", \"imuxls\")",
         "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\", \"imxs\")"
@@ -219,14 +219,14 @@
     "Timestamp": [
       {
         "description": "Timestamp with two number args",
-        "query": "Timestamp(10, 100)",
+        "javascript": "Timestamp(10, 100)",
         "python": "Timestamp(10, 100)",
         "java": "new BSONTimestamp(10, 100)",
         "csharp": "new BsonTimestamp(10, 100)"
       },
       {
         "description": "new Timestamp with two number args",
-        "query": "new Timestamp(10, 100)",
+        "javascript": "new Timestamp(10, 100)",
         "python": "Timestamp(10, 100)",
         "java": "new BSONTimestamp(10, 100)",
         "csharp": "new BsonTimestamp(10, 100)"
@@ -235,49 +235,49 @@
     "Document": [
       {
         "description": "{x: 1}",
-        "query": "{x: 1}",
+        "javascript": "{x: 1}",
         "python": "{'x': 1}",
         "java": "new Document().append(\"x\", 1)",
         "csharp": "new BsonDocument(\"x\", 1)"
       },
       {
         "description": "Doc with trailing comma",
-        "query": "{x: 1,}",
+        "javascript": "{x: 1,}",
         "python": "{'x': 1,}",
         "java": "new Document().append(\"x\", 1)",
         "csharp": "new BsonDocument(\"x\", 1)"
       },
       {
         "description": "Doc with array",
-        "query": "{x: [1, 2]}",
+        "javascript": "{x: [1, 2]}",
         "python": "{'x': [1, 2]}",
         "java": "new Document().append(\"x\", Arrays.asList(1, 2))",
         "csharp": "new BsonDocument(\"x\", new BsonArray {1, 2})"
       },
       {
         "description": "Doc with subdoc",
-        "query": "{x: {y: 2}}",
+        "javascript": "{x: {y: 2}}",
         "python": "{'x': {'y': 2}}",
         "java": "new Document().append(\"x\", new Document().append(\"y\", 2))",
         "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", 2))"
       },
       {
         "description": "Object.create()",
-        "query": "Object.create({x: 1})",
+        "javascript": "Object.create({x: 1})",
         "python": "{'x': 1}",
         "java": "new Document().append(\"x\", 1)",
         "csharp": "new BsonDocument(\"x\", 1)"
       },
       {
         "description": "Empty object",
-        "query": "{}",
+        "javascript": "{}",
         "python": "{}",
         "java": "new Document()",
         "csharp": "new BsonDocument()"
       },
       {
         "description": "Two items in document",
-        "query": "{x: 1, n: 4}",
+        "javascript": "{x: 1, n: 4}",
         "python": "{'x': 1, 'n': 4}",
         "java": "new Document().append(\"x\", 1).append(\"n\", 4)",
         "csharp": "new BsonDocument { { \"x\", 1 }, { \"n\", 4 } }"
@@ -286,35 +286,35 @@
     "Array": [
       {
         "description": "[1, 2]",
-        "query": "[1, 2]",
+        "javascript": "[1, 2]",
         "python": "[1, 2]",
         "java": "Arrays.asList(1, 2)",
         "csharp": "new BsonArray {1, 2}"
       },
       {
         "description": "array with trailing comma",
-        "query": "[1, 2,]",
+        "javascript": "[1, 2,]",
         "python": "[1, 2]",
         "java": "Arrays.asList(1, 2)",
         "csharp": "new BsonArray {1, 2}"
       },
       {
         "description": "Array with subdoc",
-        "query": "[1, { settings: 'http2' }]",
+        "javascript": "[1, { settings: 'http2' }]",
         "python": "[1, {'settings': 'http2'}]",
         "java": "Arrays.asList(1, new Document().append(\"settings\", \"http2\"))",
         "csharp": "new BsonArray {1, new BsonDocument(\"settings\", \"http2\")}"
       },
       {
         "description": "Array with subarray",
-        "query": "[1, [2, 3]]",
+        "javascript": "[1, [2, 3]]",
         "python": "[1, [2, 3]]",
         "java": "Arrays.asList(1, Arrays.asList(2, 3))",
         "csharp": "new BsonArray {1, new BsonArray {2, 3}}"
       },
       {
         "description": "Empty array",
-        "query": "[]",
+        "javascript": "[]",
         "python": "[]",
         "java": "Arrays.asList()",
         "csharp": "new BsonArray()"
@@ -323,28 +323,28 @@
     "ArrayElision": [
       {
         "description": "array with leading elision",
-        "query": "[,1, 2,]",
+        "javascript": "[,1, 2,]",
         "python": "[None, 1, 2]",
         "java": "Arrays.asList(null, 1, 2)",
         "csharp": "new BsonArray {BsonNull.Value, 1, 2}"
       },
       {
         "description": "Array with one elision",
-        "query": "[,]",
+        "javascript": "[,]",
         "python": "[None]",
         "java": "Arrays.asList(null)",
         "csharp": "new BsonArray {BsonNull.Value}"
       },
       {
         "description": "Array with 2 elision",
-        "query": "[,,]",
+        "javascript": "[,,]",
         "python": "[None, None]",
         "java": "Arrays.asList(null, null)",
         "csharp": "new BsonArray {BsonNull.Value, BsonNull.Value}"
       },
       {
         "description": "Array with elision in the middle",
-        "query": "[1,,,,2]",
+        "javascript": "[1,,,,2]",
         "python": "[1, None, None, None, 2]",
         "java": "Arrays.asList(1, null, null, null, 2)",
         "csharp": "new BsonArray {1, BsonNull.Value, BsonNull.Value, BsonNull.Value, 2}"
@@ -353,14 +353,14 @@
     "Symbol": [
       {
         "description": "Symbol from string",
-        "query": "Symbol('2')",
+        "javascript": "Symbol('2')",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\")",
         "csharp": "new BsonString(\"2\")"
       },
       {
         "description": "new Symbol from string",
-        "query": "new Symbol('2')",
+        "javascript": "new Symbol('2')",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\")",
         "csharp": "new BsonString(\"2\")"

--- a/test/json/success/bson-object-methods.json
+++ b/test/json/success/bson-object-methods.json
@@ -3,14 +3,14 @@
     "Code": [
       {
         "description": "CodeWithScope toJSON",
-        "query": "Code('test code', {x: 1}).toJSON()",
+        "javascript": "Code('test code', {x: 1}).toJSON()",
         "python": "",
         "java": "new Document().append(\"code\", \"test code\").append(\"scope\", new Document().append(\"x\", 1))",
         "csharp": ""
       },
       {
         "description": "Code toJSON",
-        "query": "Code('test code').toJSON()",
+        "javascript": "Code('test code').toJSON()",
         "python": "",
         "java": "new Document().append(\"code\", \"test code\").append(\"scope\", undefined)",
         "csharp": ""
@@ -19,42 +19,42 @@
     "ObjectId": [
       {
         "description": "no arguments toJSON",
-        "query": "ObjectId().toJSON()",
+        "javascript": "ObjectId().toJSON()",
         "python": "",
         "java": "new ObjectId().toHexString()",
         "csharp": ""
       },
       {
         "description": "hex arg toJSON",
-        "query": "ObjectId('5ab901c29ee65f5c8550c5b9').toJSON()",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toJSON()",
         "python": "",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toHexString()",
         "csharp": ""
       },
       {
         "description": "no arg toString",
-        "query": "ObjectId().toString()",
+        "javascript": "ObjectId().toString()",
         "python": "",
         "java": "new ObjectId().toString()",
         "csharp": ""
       },
       {
         "description": "hex arg toString",
-        "query": "ObjectId('5ab901c29ee65f5c8550c5b9').toString()",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toString()",
         "python": "",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toString()",
         "csharp": ""
       },
       {
         "description": "getTimestamp",
-        "query": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()",
         "python": "",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").getTimestamp()",
         "csharp": ""
       },
       {
         "description": "equals",
-        "query": "ObjectId().equals(ObjectId())",
+        "javascript": "ObjectId().equals(ObjectId())",
         "python": "",
         "java": "new ObjectId().equals(new ObjectId())",
         "csharp": ""
@@ -63,28 +63,28 @@
     "Binary": [
       {
         "description": "length",
-        "query": "Binary(Buffer.from('a string')).length()",
+        "javascript": "Binary(Buffer.from('a string')).length()",
         "python": "",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).length()",
         "csharp": ""
       },
       {
         "description": "value",
-        "query": "Binary(Buffer.from('a string')).value()",
+        "javascript": "Binary(Buffer.from('a string')).value()",
         "python": "",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).getData()",
         "csharp": ""
       },
       {
         "description": "toString",
-        "query": "Binary(Buffer.from('a string')).toString()",
+        "javascript": "Binary(Buffer.from('a string')).toString()",
         "python": "",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
         "csharp": ""
       },
       {
         "description": "toJSON",
-        "query": "Binary(Buffer.from('a string')).toJSON()",
+        "javascript": "Binary(Buffer.from('a string')).toJSON()",
         "python": "",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
         "csharp": ""
@@ -93,14 +93,14 @@
     "DBRef": [
       {
         "description": "toJSON with two args",
-        "query": "new DBRef('coll', new ObjectId()).toJSON()",
+        "javascript": "new DBRef('coll', new ObjectId()).toJSON()",
         "python": "",
         "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"\")",
         "csharp": ""
       },
       {
         "description": "toJSON with three args",
-        "query": "new DBRef('coll', new ObjectId(), 'db').toJSON()",
+        "javascript": "new DBRef('coll', new ObjectId(), 'db').toJSON()",
         "python": "",
         "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"db\")",
         "csharp": ""
@@ -109,14 +109,14 @@
     "Int32": [
       {
         "description": "toJSON",
-        "query": "Int32(3).toJSON()",
+        "javascript": "Int32(3).toJSON()",
         "python": "",
         "java": "new java.lang.Integer(3).intValue()",
         "csharp": ""
       },
       {
         "description": "valueOf",
-        "query": "Int32(3).valueOf()",
+        "javascript": "Int32(3).valueOf()",
         "python": "",
         "java": "new java.lang.Integer(3).intValue()",
         "csharp": ""
@@ -125,14 +125,14 @@
     "Double": [
       {
         "description": "toJSON",
-        "query": "Double(3).toJSON()",
+        "javascript": "Double(3).toJSON()",
         "python": "",
         "java": "new java.lang.Double(3).doubleValue()",
         "csharp": ""
       },
       {
         "description": "valueOf",
-        "query": "Double(3).valueOf()",
+        "javascript": "Double(3).valueOf()",
         "python": "",
         "java": "new java.lang.Double(3).doubleValue()",
         "csharp": ""
@@ -141,189 +141,189 @@
     "Long": [
       {
         "description": "toJSON",
-        "query": "Long(1, 100).toJSON()",
+        "javascript": "Long(1, 100).toJSON()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").toString()",
         "csharp": ""
       },
       {
         "description": "toInt",
-        "query": "Long(1, 100).toInt()",
+        "javascript": "Long(1, 100).toInt()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").intValue()",
         "csharp": ""
       },
       {
         "description": "toNumber",
-        "query": "Long(1, 100).toNumber()",
+        "javascript": "Long(1, 100).toNumber()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").floatValue()",
         "csharp": ""
       },
       {
         "description": "toString without radix",
-        "query": "Long(1, 100).toString()",
+        "javascript": "Long(1, 100).toString()",
         "python": "",
         "java": "java.lang.Long.toString(429496729601)",
         "csharp": ""
       },
       {
         "description": "toString with radix",
-        "query": "Long(1, 100).toString(10)",
+        "javascript": "Long(1, 100).toString(10)",
         "python": "",
         "java": "java.lang.Long.toString(429496729601, 10)",
         "csharp": ""
       },
       {
         "description": "isZero",
-        "query": "Long(1, 100).isZero()",
+        "javascript": "Long(1, 100).isZero()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(0))",
         "csharp": ""
       },
       {
         "description": "isNegative",
-        "query": "Long(1, 100).isNegative()",
+        "javascript": "Long(1, 100).isNegative()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(0)) < 0",
         "csharp": ""
       },
       {
         "description": "isOdd",
-        "query": "Long(1, 100).isOdd()",
+        "javascript": "Long(1, 100).isOdd()",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") % 2 == 0",
         "csharp": ""
       },
       {
         "description": "equals",
-        "query": "Long(1, 100).equals(Long(9, 1))",
+        "javascript": "Long(1, 100).equals(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(\"4294967305\"))",
         "csharp": ""
       },
       {
         "description": "notEquals",
-        "query": "Long(1, 100).notEquals(Long(9, 1))",
+        "javascript": "Long(1, 100).notEquals(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) != 0",
         "csharp": ""
       },
       {
         "description": "compare",
-        "query": "Long(1, 100).compare(Long(9, 1))",
+        "javascript": "Long(1, 100).compare(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\"))",
         "csharp": ""
       },
       {
         "description": "greaterThan",
-        "query": "Long(1, 100).greaterThan(Long(9, 1))",
+        "javascript": "Long(1, 100).greaterThan(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) > 0",
         "csharp": ""
       },
       {
         "description": "greaterThanOrEqual",
-        "query": "Long(1, 100).greaterThanOrEqual(Long(9, 1))",
+        "javascript": "Long(1, 100).greaterThanOrEqual(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) >= 0",
         "csharp": ""
       },
       {
         "description": "lessThan",
-        "query": "Long(1, 100).lessThan(Long(9, 1))",
+        "javascript": "Long(1, 100).lessThan(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) < 0",
         "csharp": ""
       },
       {
         "description": "lessThanOrEqual",
-        "query": "Long(1, 100).lessThanOrEqual(Long(9, 1))",
+        "javascript": "Long(1, 100).lessThanOrEqual(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) <= 0",
         "csharp": ""
       },
       {
         "description": "negate",
-        "query": "Long(1, 100).negate())",
+        "javascript": "Long(1, 100).negate())",
         "python": "",
         "java": "-new java.lang.Long(\"429496729601\")",
         "csharp": ""
       },
       {
         "description": "add",
-        "query": "Long(1, 100).add(Long(9, 1))",
+        "javascript": "Long(1, 100).add(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") + new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "subtract",
-        "query": "Long(1, 100).subtract(Long(9, 1))",
+        "javascript": "Long(1, 100).subtract(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") - new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "multiply",
-        "query": "Long(1, 100).multiply(Long(9, 1))",
+        "javascript": "Long(1, 100).multiply(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") * new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "div",
-        "query": "Long(1, 100).div(Long(9, 1))",
+        "javascript": "Long(1, 100).div(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") / new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "modulo",
-        "query": "Long(1, 100).modulo(Long(9, 1))",
+        "javascript": "Long(1, 100).modulo(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") % new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "not",
-        "query": "Long(1, 100).not()",
+        "javascript": "Long(1, 100).not()",
         "python": "",
         "java": "~new java.lang.Long(\"429496729601\")",
         "csharp": ""
       },
       {
         "description": "and",
-        "query": "Long(1, 100).and(Long(9, 1))",
+        "javascript": "Long(1, 100).and(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") & new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "or",
-        "query": "Long(1, 100).or(Long(9, 1))",
+        "javascript": "Long(1, 100).or(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") | new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "xor",
-        "query": "Long(1, 100).xor(Long(9, 1))",
+        "javascript": "Long(1, 100).xor(Long(9, 1))",
         "python": "",
         "java": "new java.lang.Long(\"429496729601\") ^ new java.lang.Long(\"4294967305\")",
         "csharp": ""
       },
       {
         "description": "shiftLeft",
-        "query": "Long(1, 100).shiftLeft(10)",
+        "javascript": "Long(1, 100).shiftLeft(10)",
         "python": "",
         "java": "java.lang.Long.rotateLeft(new java.lang.Long(\"429496729601\"), 10)",
         "csharp": ""
       },
       {
         "description": "shiftRight",
-        "query": "Long(1, 100).shiftRight(10)",
+        "javascript": "Long(1, 100).shiftRight(10)",
         "python": "",
         "java": "java.lang.Long.rotateRight(new java.lang.Long(\"429496729601\"), 10)",
         "csharp": ""
@@ -332,14 +332,14 @@
     "Decimal128": [
       {
         "description": "toString",
-        "query": "new Decimal128(Buffer.from('5')).toString()",
+        "javascript": "new Decimal128(Buffer.from('5')).toString()",
         "python": "",
         "java": "Decimal128.parse(\"5.3E-6175\").toString()",
         "csharp": ""
       },
       {
         "description": "toJSON",
-        "query": "new Decimal128(Buffer.from('5')).toJSON()",
+        "javascript": "new Decimal128(Buffer.from('5')).toJSON()",
         "python": "",
         "java": "new Document().append(\"$numberDecimal\", Decimal128.parse(\"5.3E-6175\").toString())",
         "csharp": ""
@@ -348,77 +348,77 @@
     "Timestamp": [
       {
         "description": "toJSON",
-        "query": "Timestamp(1, 100).toJSON()",
+        "javascript": "Timestamp(1, 100).toJSON()",
         "python": "",
         "java": "new BSONTimestamp(1, 100).toString()",
         "csharp": ""
       },
       {
         "description": "toString",
-        "query": "Timestamp(1, 100).toString()",
+        "javascript": "Timestamp(1, 100).toString()",
         "python": "",
         "java": "new BSONTimestamp(1, 100).toString()",
         "csharp": ""
       },
       {
         "description": "equals",
-        "query": "Timestamp(1, 100).equals(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).equals(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).equals(new BSONTimestamp(2, 99))",
         "csharp": ""
       },
       {
         "description": "compare",
-        "query": "Timestamp(1, 100).compare(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).compare(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99))",
         "csharp": ""
       },
       {
         "description": "notEquals",
-        "query": "Timestamp(1, 100).notEquals(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).notEquals(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) != 0",
         "csharp": ""
       },
       {
         "description": "greaterThan",
-        "query": "Timestamp(1, 100).greaterThan(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).greaterThan(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) > 0",
         "csharp": ""
       },
       {
         "description": "greaterThanOrEqual",
-        "query": "Timestamp(1, 100).greaterThanOrEqual(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).greaterThanOrEqual(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) >= 0",
         "csharp": ""
       },
       {
         "description": "lessThan",
-        "query": "Timestamp(1, 100).lessThan(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).lessThan(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) < 0",
         "csharp": ""
       },
       {
         "description": "lessThanOrEqual",
-        "query": "Timestamp(1, 100).lessThanOrEqual(Timestamp(2, 99))",
+        "javascript": "Timestamp(1, 100).lessThanOrEqual(Timestamp(2, 99))",
         "python": "",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) <= 0",
         "csharp": ""
       },
       {
         "description": "getLowBits",
-        "query": "Timestamp(1, 100).getLowBits()",
+        "javascript": "Timestamp(1, 100).getLowBits()",
         "python": "",
         "java": "new BSONTimestamp(1, 100).getTime()",
         "csharp": ""
       },
       {
         "description": "getHighBits",
-        "query": "Timestamp(1, 100).getHighBits()",
+        "javascript": "Timestamp(1, 100).getHighBits()",
         "python": "",
         "java": "new BSONTimestamp(1, 100).getInc()",
         "csharp": ""
@@ -427,28 +427,28 @@
     "Symbol": [
       {
         "description": "valueOf",
-        "query": "Symbol('2').valueOf()",
+        "javascript": "Symbol('2').valueOf()",
         "python": "",
         "java": "new Symbol(\"2\").getSymbol()",
         "csharp": ""
       },
       {
         "description": "toString",
-        "query": "Symbol('2').toString()",
+        "javascript": "Symbol('2').toString()",
         "python": "",
         "java": "new Symbol(\"2\").toString()",
         "csharp": ""
       },
       {
         "description": "inspect",
-        "query": "Symbol('2').inspect()",
+        "javascript": "Symbol('2').inspect()",
         "python": "",
         "java": "new Symbol(\"2\").getSymbol()",
         "csharp": ""
       },
       {
         "description": "toJSON",
-        "query": "Symbol('2').toJSON()",
+        "javascript": "Symbol('2').toJSON()",
         "python": "",
         "java": "new Symbol(\"2\").toString()",
         "csharp": ""

--- a/test/json/success/bson-utils.json
+++ b/test/json/success/bson-utils.json
@@ -3,21 +3,21 @@
     "ObjectId": [
       {
         "description": "createFromHexString",
-        "query": "ObjectId.createFromHexString('5ab901c29ee65f5c8550c5b9')",
+        "javascript": "ObjectId.createFromHexString('5ab901c29ee65f5c8550c5b9')",
         "python": "",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\")",
         "csharp": ""
       },
       {
         "description": "createFromTime",
-        "query": "ObjectId.createFromTime(1522075031642)",
+        "javascript": "ObjectId.createFromTime(1522075031642)",
         "python": "",
         "java": "new ObjectId(new java.util.Date(1522075031642))",
         "csharp": ""
       },
       {
         "description": "isValid",
-        "query": "ObjectId.isValid('5ab901c29ee65f5c8550c5b9')",
+        "javascript": "ObjectId.isValid('5ab901c29ee65f5c8550c5b9')",
         "python": "",
         "java": "ObjectId.isValid(\"5ab901c29ee65f5c8550c5b9\")",
         "csharp": ""
@@ -26,49 +26,49 @@
     "Binary": [
       {
         "description": "subtype default",
-        "query": "Binary.SUBTYPE_DEFAULT",
+        "javascript": "Binary.SUBTYPE_DEFAULT",
         "python": "",
         "java": "org.bson.BsonBinarySubType.BINARY",
         "csharp": ""
       },
       {
         "description": "subtype function",
-        "query": "Binary.SUBTYPE_FUNCTION",
+        "javascript": "Binary.SUBTYPE_FUNCTION",
         "python": "",
         "java": "org.bson.BsonBinarySubType.FUNCTION",
         "csharp": ""
       },
       {
         "description": "subtype byte array",
-        "query": "Binary.SUBTYPE_BYTE_ARRAY",
+        "javascript": "Binary.SUBTYPE_BYTE_ARRAY",
         "python": "",
         "java": "org.bson.BsonBinarySubType.OLD_BINARY",
         "csharp": ""
       },
       {
         "description": "subtype uuid old",
-        "query": "Binary.SUBTYPE_UUID_OLD",
+        "javascript": "Binary.SUBTYPE_UUID_OLD",
         "python": "",
         "java": "org.bson.BsonBinarySubType.UUID_LEGACY",
         "csharp": ""
       },
       {
         "description": "subtype uuid",
-        "query": "Binary.SUBTYPE_UUID",
+        "javascript": "Binary.SUBTYPE_UUID",
         "python": "",
         "java": "org.bson.BsonBinarySubType.UUID",
         "csharp": ""
       },
       {
         "description": "subtype md5",
-        "query": "Binary.SUBTYPE_MD5",
+        "javascript": "Binary.SUBTYPE_MD5",
         "python": "",
         "java": "org.bson.BsonBinarySubType.MD5",
         "csharp": ""
       },
       {
         "description": "subtype udef",
-        "query": "Binary.SUBTYPE_USER_DEFINED",
+        "javascript": "Binary.SUBTYPE_USER_DEFINED",
         "python": "",
         "java": "org.bson.BsonBinarySubType.USER_DEFINED",
         "csharp": ""
@@ -77,63 +77,63 @@
     "Long": [
       {
         "description": "MAX_VALUE",
-        "query": "Long.MAX_VALUE",
+        "javascript": "Long.MAX_VALUE",
         "python": "",
         "java": "java.lang.Long.MAX_VALUE",
         "csharp": ""
       },
       {
         "description": "MIN_VALUE",
-        "query": "Long.MIN_VALUE",
+        "javascript": "Long.MIN_VALUE",
         "python": "",
         "java": "java.lang.Long.MIN_VALUE",
         "csharp": ""
       },
       {
         "description": "ZERO",
-        "query": "Long.ZERO",
+        "javascript": "Long.ZERO",
         "python": "",
         "java": "new java.lang.Long(0)",
         "csharp": ""
       },
       {
         "description": "ONE",
-        "query": "Long.ONE",
+        "javascript": "Long.ONE",
         "python": "",
         "java": "new java.lang.Long(1)",
         "csharp": ""
       },
       {
         "description": "NEG_ONE",
-        "query": "Long.NEG_ONE",
+        "javascript": "Long.NEG_ONE",
         "python": "",
         "java": "new java.lang.Long(-1)",
         "csharp": ""
       },
       {
         "description": "fromInt",
-        "query": "Long.fromInt(5)",
+        "javascript": "Long.fromInt(5)",
         "python": "",
         "java": "new java.lang.Long(5)",
         "csharp": ""
       },
       {
         "description": "fromString without radix",
-        "query": "Long.fromString('5')",
+        "javascript": "Long.fromString('5')",
         "python": "",
         "java": "java.lang.Long.parseLong(\"5\")",
         "csharp": ""
       },
       {
         "description": "fromString with radix",
-        "query": "Long.fromString('5', 10)",
+        "javascript": "Long.fromString('5', 10)",
         "python": "",
         "java": "java.lang.Long.parseLong(\"5\", 10)",
         "csharp": ""
       },
       {
         "description": "fromBits",
-        "query": "Long.fromBits(-1, 2147483647)",
+        "javascript": "Long.fromBits(-1, 2147483647)",
         "python": "",
         "java": "new java.lang.Long(\"9223372036854775807\")",
         "csharp": ""
@@ -142,7 +142,7 @@
     "Decimal128": [
       {
         "description": "fromString",
-        "query": "Decimal128.fromString(\"5\")",
+        "javascript": "Decimal128.fromString(\"5\")",
         "python": "",
         "java": "Decimal128.parse(\"5\")",
         "csharp": ""

--- a/test/json/success/js-constructors.json
+++ b/test/json/success/js-constructors.json
@@ -3,14 +3,14 @@
     "math": [
       {
         "description": "simple addition",
-        "query": "2+5",
+        "javascript": "2+5",
         "python": "2+5",
         "java": "2+5",
         "csharp": "2+5"
       },
       {
         "description": "multiplication and division",
-        "query": "2+(4*36)/3",
+        "javascript": "2+(4*36)/3",
         "python": "2+(4*36)/3",
         "java": "2+(4*36)/3",
         "csharp": "2+(4*36)/3"
@@ -19,14 +19,14 @@
     "Number": [
       {
         "description": "Number with number arg",
-        "query": "new Number(2)",
+        "javascript": "new Number(2)",
         "python": "int(2)",
         "java": "new java.lang.Integer(2)",
         "csharp": "new int(2)"
       },
       {
         "description": "Number with valid string arg",
-        "query": "new Number('2')",
+        "javascript": "new Number('2')",
         "python": "int(2)",
         "java": "new java.lang.Integer(\"2\")",
         "csharp": "new int(2)"
@@ -35,98 +35,98 @@
     "literals": [
       {
         "description": "Integer 2",
-        "query": "2",
+        "javascript": "2",
         "python": "2",
         "java": "2",
         "csharp": "2"
       },
       {
         "description": "Decimal 2.001",
-        "query": "2.001",
+        "javascript": "2.001",
         "python": "2.001",
         "java": "2.001",
         "csharp": "2.001"
       },
       {
         "description": "Hex number caps",
-        "query": "0X123ABC",
+        "javascript": "0X123ABC",
         "python": "0X123ABC",
         "java": "0X123ABC",
         "csharp": "0X123ABC"
       },
       {
         "description": "Hex number lower",
-        "query": "0x123abc",
+        "javascript": "0x123abc",
         "python": "0x123abc",
         "java": "0x123abc",
         "csharp": "0x123abc"
       },
       {
         "description": "Octal 0-prefix number",
-        "query": "01234567",
+        "javascript": "01234567",
         "python": "0o1234567",
         "java": "01234567",
         "csharp": "1234567"
       },
       {
         "description": "Octal 00-prefix number",
-        "query": "001234567",
+        "javascript": "001234567",
         "python": "0o1234567",
         "java": "01234567",
         "csharp": "1234567"
       },
       {
         "description": "Octal 0o-prefix number",
-        "query": "0o1234567",
+        "javascript": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
         "csharp": "0"
       },
       {
         "description": "Octal 0O-prefix number",
-        "query": "0o1234567",
+        "javascript": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
         "csharp": "0"
       },
       {
         "description": "Single-quote string",
-        "query": "'string'",
+        "javascript": "'string'",
         "python": "'string'",
         "java": "\"string\"",
         "csharp": "\"string\""
       },
       {
         "description": "Double-quote string",
-        "query": "\"string\"",
+        "javascript": "\"string\"",
         "python": "'string'",
         "java": "\"string\"",
         "csharp": "\"string\""
       },
       {
         "description": "null",
-        "query": "null",
+        "javascript": "null",
         "python": "None",
         "java": "null",
         "csharp": "BsonNull.Value"
       },
       {
         "description": "undefined",
-        "query": "undefined",
+        "javascript": "undefined",
         "python": "None",
         "java": "null",
         "csharp": "BsonUndefined.Value"
       },
       {
         "description": "true",
-        "query": "true",
+        "javascript": "true",
         "python": "True",
         "java": "true",
         "csharp": "true"
       },
       {
         "description": "false",
-        "query": "false",
+        "javascript": "false",
         "python": "False",
         "java": "false",
         "csharp": "false"
@@ -135,35 +135,35 @@
     "Date": [
       {
         "description": "new Date with ISO String",
-        "query": "new Date('December 17, 1995 03:24:00Z')",
+        "javascript": "new Date('December 17, 1995 03:24:00Z')",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819170640000)",
         "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
       },
       {
         "description": "new Date with UTC number",
-        "query": "new Date(819167040000)",
+        "javascript": "new Date(819167040000)",
         "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819167040000)",
         "csharp": "new DateTime(1995, 12, 17, 2, 24, 0)"
       },
       {
         "description": "Current date",
-        "query": "new Date()",
+        "javascript": "new Date()",
         "python": "datetime.datetime.utcnow().date()",
         "java": "new java.util.Date()",
         "csharp": "DateTime.Now"
       },
       {
         "description": "Date from year, month and day",
-        "query": "new Date(1995, 11, 17)",
+        "javascript": "new Date(1995, 11, 17)",
         "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819158400000)",
         "csharp": "new DateTime(1995, 12, 17, 0, 0, 0)"
       },
       {
         "description": "Date from year, month, day, hour, min and sec",
-        "query": "new Date(1995, 11, 17, 3, 24, 0)",
+        "javascript": "new Date(1995, 11, 17, 3, 24, 0)",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(819170640000)",
         "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
@@ -172,84 +172,84 @@
     "RegExp": [
       {
         "description": "empty RegExp",
-        "query": "RegExp('')",
+        "javascript": "RegExp('')",
         "python": "re.compile(r\"(?:)\")",
         "java": "Pattern.compile(\"(?:)\")",
         "csharp": ""
       },
       {
         "description": "RegExp without options",
-        "query": "RegExp('abc')",
+        "javascript": "RegExp('abc')",
         "python": "re.compile(r\"abc\")",
         "java": "Pattern.compile(\"abc\")",
         "csharp": ""
       },
       {
         "description": "regex object with im flags as args",
-        "query": "new RegExp('ab+c', 'im')",
+        "javascript": "new RegExp('ab+c', 'im')",
         "python": "re.compile(r\"ab+c(?im)\")",
         "java": "Pattern.compile(\"ab+c(?im)\")",
         "csharp": ""
       },
       {
         "description": "regex object with ig flags as args",
-        "query": "new RegExp('ab+c', 'ig')",
+        "javascript": "new RegExp('ab+c', 'ig')",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
         "csharp": ""
       },
       {
         "description": "regex object with forward slash",
-        "query": "new RegExp('ab/cd')",
+        "javascript": "new RegExp('ab/cd')",
         "python": "re.compile(r\"ab\\/cd\")",
         "java": "Pattern.compile(\"ab\\/cd\")",
         "csharp": ""
       },
       {
         "description": "regex object with escaped double quote",
-        "query": "new RegExp('ab\\\"ab')",
+        "javascript": "new RegExp('ab\\\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
         "csharp": ""
       },
       {
         "description": "regex object with nonescaped double quote",
-        "query": "new RegExp('ab\"ab')",
+        "javascript": "new RegExp('ab\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
         "csharp": ""
       },
       {
         "description": "regex object with escaped single quote",
-        "query": "new RegExp('ab\\'ab')",
+        "javascript": "new RegExp('ab\\'ab')",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
         "csharp": ""
       },
       {
         "description": "regex object with nonescaped single quote",
-        "query": "new RegExp(\"ab'ab\")",
+        "javascript": "new RegExp(\"ab'ab\")",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
         "csharp": ""
       },
       {
         "description": "regex object with newline",
-        "query": "new RegExp(\"\\\\n\")",
+        "javascript": "new RegExp(\"\\\\n\")",
         "python": "re.compile(r\"\\\\n\")",
         "java": "Pattern.compile(\"\\\\n\")",
         "csharp": ""
       },
       {
         "description": "regex literal with ig flags",
-        "query": "/ab+c/ig",
+        "javascript": "/ab+c/ig",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
         "csharp": ""
       },
       {
         "description": "regex object with regex literal arg",
-        "query": "new RegExp(/ab+c/, 'i')",
+        "javascript": "new RegExp(/ab+c/, 'i')",
         "python": "re.compile(r\"ab+c(?i)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
         "csharp": ""

--- a/test/json/success/js-utils.json
+++ b/test/json/success/js-utils.json
@@ -3,7 +3,7 @@
     "Date": [
       {
         "description": "Current time",
-        "query": "Date.now()",
+        "javascript": "Date.now()",
         "python": "datetime.datetime.utcnow()",
         "java": "new java.util.Date()",
         "csharp": ""


### PR DESCRIPTION
Now usage should look like:
```
const input = 'javascript';
const output = 'java';
const compiler = require('bson-compilers');
compiler[input][output]("some code in js to compile to java");
// or
compiler.javascript.java("some code in js to compile to java");
```
Tests have been updated to use the new API. Also some minor style/comment fixes.