### PR TITLE
COMPASS-2754 - Separate json test files by input language

### DIFF
--- a/test/code-generation.test.js
+++ b/test/code-generation.test.js
@@ -3,31 +3,28 @@ const fs = require('fs');
 const path = require('path');
 
 const outputLanguages = ['java', 'python', 'csharp'];
-const inputLanguages = ['javascript'];
+const inputLanguages = ['javascript', 'shell'];
 
 describe('Test', () => {
   const pSuccess = path.join(__dirname, 'json', 'success');
   const pError = path.join(__dirname, 'json', 'error');
 
-  const filesSuccess = fs.readdirSync(pSuccess);
-  const filesError = fs.readdirSync(pError);
+  inputLanguages.forEach((inputLang) => {
+    fs.readdirSync(path.join(pSuccess, inputLang)).map((file) => {
+      const tests = readJSON(path.join(pSuccess, inputLang, file)).tests;
+      const testname = file.replace('.json', '');
 
-  filesSuccess.map((file) => {
-    const tests = readJSON(path.join(pSuccess, file)).tests;
-    const testname = file.replace('.json', '');
-
-    inputLanguages.forEach((inputLang) => {
       outputLanguages.forEach((outputLang) => {
         runTest('success', testname, inputLang, outputLang, tests);
       });
     });
   });
 
-  filesError.map((file) => {
-    const tests = readJSON(path.join(pError, file)).tests;
-    const testname = file.replace('.json', '');
+  inputLanguages.forEach((inputLang) => {
+    fs.readdirSync(path.join(pError, inputLang)).map((file) => {
+      const tests = readJSON(path.join(pError, inputLang, file)).tests;
+      const testname = file.replace('.json', '');
 
-    inputLanguages.forEach((inputLang) => {
       outputLanguages.forEach((outputLang) => {
         runTest('error', testname, inputLang, outputLang, tests);
       });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,26 +8,58 @@ const compiler = require('../');
 // Need a way to have test pass while developing
 const unsupported = {
   success: {
-    java: {},
-    python: {
-      'bson-constructors': [ '*' ],
-      'js-constructors': [ '*' ],
-      'bson-object-methods': [ '*' ],
-      'bson-utils': [ '*' ],
-      'js-utils': [ '*' ]
+    javascript: {
+      java: {},
+      python: {
+        'bson-constructors': [ '*' ],
+        'js-constructors': [ '*' ],
+        'bson-object-methods': [ '*' ],
+        'bson-utils': [ '*' ],
+        'js-utils': [ '*' ]
+      },
+      csharp: {
+        'bson-constructors': [ '*' ],
+        'js-constructors': [ '*' ],
+        'bson-object-methods': [ '*' ],
+        'bson-utils': [ '*' ],
+        'js-utils': [ '*' ]
+      }
     },
-    csharp: {
-      'bson-constructors': [ '*' ],
-      'js-constructors': [ '*' ],
-      'bson-object-methods': [ '*' ],
-      'bson-utils': [ '*' ],
-      'js-utils': [ '*' ]
+    shell: {
+      java: {
+        'bson-constructors': [ 'Code', 'ObjectId', 'Binary', 'DBRef', 'Double', 'Int32', 'Long', 'MinKey/MaxKey', 'BSONRegExp', 'Timestamp', 'Decimal128', 'Symbol', 'ArrayElision', 'Document', 'Array'],
+        'js-constructors': [ '*' ],
+        'bson-object-methods': [ '*' ],
+        'bson-utils': [ '*' ],
+        'js-utils': [ '*' ]
+      },
+      python: {
+        'bson-constructors': [ '*' ],
+        'js-constructors': [ '*' ],
+        'bson-object-methods': [ '*' ],
+        'bson-utils': [ '*' ],
+        'js-utils': [ '*' ]
+      },
+      csharp: {
+        'bson-constructors': [ '*' ],
+        'js-constructors': [ '*' ],
+        'bson-object-methods': [ '*' ],
+        'bson-utils': [ '*' ],
+        'js-utils': [ '*' ]
+      }
     }
   },
   error: {
-    java: {'bson-constructors': [ '*' ]},
-    python: { 'bson-constructors': [ '*' ]},
-    csharp: {'bson-constructors': [ '*' ]}
+    javascript: {
+      java: {'bson-constructors': [ '*' ]},
+      python: { 'bson-constructors': [ '*' ]},
+      csharp: {'bson-constructors': [ '*' ]}
+    },
+    shell: {
+      java: {'bson-constructors': [ '*' ]},
+      python: { 'bson-constructors': [ '*' ]},
+      csharp: {'bson-constructors': [ '*' ]}
+    }
   }
 };
 
@@ -61,9 +93,9 @@ const runTest = function(mode, testname, inputLang, outputLang, tests) {
       describe(key, () => {
         tests[key].map((test) => {
           const skip = (
-            testname in unsupported[mode][outputLang] &&
-            (unsupported[mode][outputLang][testname].indexOf('*') !== -1 ||
-             unsupported[mode][outputLang][testname].indexOf(key) !== -1)
+            testname in unsupported[mode][inputLang][outputLang] &&
+            (unsupported[mode][inputLang][outputLang][testname].indexOf('*') !== -1 ||
+             unsupported[mode][inputLang][outputLang][testname].indexOf(key) !== -1)
           );
 
           (skip ? xit : it)(

--- a/test/json/error/javascript/bson-constructors.json
+++ b/test/json/error/javascript/bson-constructors.json
@@ -1,0 +1,18 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "Code without arg",
+        "query": "new Code()",
+        "errorCode": "E_SEMANTIC_ARGUMENTCOUNTMISMATCH"
+      }
+    ],
+    "Document": [
+      {
+        "description": "Document without colon",
+        "query": "{x 1}",
+        "errorCode": "E_SYNTAX_GENERIC"
+      }
+    ]
+  }
+}

--- a/test/json/error/shell/bson-constructors.json
+++ b/test/json/error/shell/bson-constructors.json
@@ -1,0 +1,18 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "Code without arg",
+        "query": "new Code()",
+        "errorCode": "E_SEMANTIC_ARGUMENTCOUNTMISMATCH"
+      }
+    ],
+    "Document": [
+      {
+        "description": "Document without colon",
+        "query": "{x 1}",
+        "errorCode": "E_SYNTAX_GENERIC"
+      }
+    ]
+  }
+}

--- a/test/json/success/javascript/bson-constructors.json
+++ b/test/json/success/javascript/bson-constructors.json
@@ -1,0 +1,405 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "new Code with string arg",
+        "javascript": "new Code('some code')",
+        "python": "Code('some code')",
+        "java": "new Code(\"some code\")",
+        "csharp": "new BsonJavaScript(@\"some code\")",
+        "shell": "Code('some code')"
+      },
+      {
+        "description": "Code with string code",
+        "javascript": "Code('some code')",
+        "python": "Code('some code')",
+        "java": "new Code(\"some code\")",
+        "csharp": "new BsonJavaScript(@\"some code\")",
+        "shell": "Code('some code')"
+      },
+      {
+        "description": "Code with string code and object scope",
+        "javascript": "Code('string', {x: 1})",
+        "python": "Code('string', {'x': 1})",
+        "java": "new CodeWithScope(\"string\", new Document().append(\"x\", 1))",
+        "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", 1))",
+        "shell": "Code('string', {x: 1})"
+      },
+      {
+        "description": "Code with function code",
+        "javascript": "Code(function(test) { console.log(test); })",
+        "python": "Code('function(test){console.log(test);}')",
+        "java": "new Code(\"function(test){console.log(test);}\")",
+        "csharp": "new BsonJavaScript(@\"function(test){console.log(test);}\")",
+        "shell": "Code('function(test){console.log(test);}')"
+      },
+      {
+        "description": "Code with where code",
+        "javascript": "new Code('this.a > i', { i: 1 })",
+        "python": "Code('this.a > i', {'i': 1})",
+        "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", 1))",
+        "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", 1))",
+        "shell": "Code('this.a > i', {i: 1})"
+      }
+    ],
+    "ObjectId": [
+      {
+        "description": "ObjectId with no arg",
+        "javascript": "ObjectId()",
+        "python": "ObjectId()",
+        "java": "new ObjectId()",
+        "csharp": "new BsonObjectId()",
+        "shell": "ObjectId()"
+      },
+      {
+        "description": "new ObjectId with no arg",
+        "javascript": "new ObjectId()",
+        "python": "ObjectId()",
+        "java": "new ObjectId()",
+        "csharp": "new BsonObjectId()",
+        "shell": "new ObjectId()"
+      },
+      {
+        "description": "ObjectId with hex string arg",
+        "javascript": "ObjectId('5a7382114ec1f67ae445f778')",
+        "python": "ObjectId('5a7382114ec1f67ae445f778')",
+        "java": "new ObjectId(\"5a7382114ec1f67ae445f778\")",
+        "csharp": "new BsonObjectId(\"5a7382114ec1f67ae445f778\")",
+        "shell": "new ObjectId('5a7382114ec1f67ae445f778')"
+      }
+    ],
+    "Binary": [
+      {
+        "description": "Binary with ascii buffer arg",
+        "javascript": "Binary(Buffer.from('a string'))",
+        "python": "Binary(bytes('a string', 'utf-8'))",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"))",
+        "shell": ""
+      },
+      {
+        "description": "new Binary with (ascii buffer, UUID subtype enum) args",
+        "javascript": "new Binary(Buffer.from(\"a string\"), Binary.SUBTYPE_UUID)",
+        "python": "Binary(bytes('a string', 'utf-8'), bson.binary.UUID_SUBTYPE)",
+        "java": "new Binary(org.bson.BsonBinarySubType.UUID, \"a string\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.UuidStandard)",
+        "shell": ""
+      },
+      {
+        "description": "Binary with (ascii buffer, number) args",
+        "javascript": "Binary(Buffer.from('a string'), '1')",
+        "python": "Binary(bytes('a string', 'utf-8'), bson.binary.FUNCTION_SUBTYPE)",
+        "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"a string\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.Function)",
+        "shell": ""
+      },
+      {
+        "description": "Binary with string args",
+        "javascript": "Binary('a string')",
+        "python": "Binary(bytes('a string', 'utf-8'))",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"))",
+        "shell": ""
+      },
+      {
+        "description": "Binary with (string, string) args",
+        "javascript": "Binary('a string', '1')",
+        "python": "Binary(bytes('a string', 'utf-8'), bson.binary.FUNCTION_SUBTYPE)",
+        "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"a string\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\"), BsonBinarySubType.Function)"
+      }
+    ],
+    "DBRef": [
+      {
+        "description": "new DBRef with (string, ObjectID) args",
+        "javascript": "new DBRef('coll', new ObjectId())",
+        "python": "DBRef('coll', ObjectId())",
+        "java": "new DBRef(\"coll\", new ObjectId())",
+        "csharp": "DBRef(\"coll\", new BsonObjectId())",
+        "shell": ""
+      },
+      {
+        "description": "new DBRef with (string, ObjectId, string) args",
+        "javascript": "new DBRef('coll', ObjectId(), 'db')",
+        "python": "DBRef('coll', ObjectId(), 'db')",
+        "java": "new DBRef(\"coll\", new ObjectId(), \"db\")",
+        "csharp": "DBRef(\"coll\", new BsonObjectId(), \"db\")"
+      }
+    ],
+    "Int32": [
+      {
+        "description": "Int32 with number arg",
+        "javascript": "Int32(3)",
+        "python": "int(3)",
+        "java": "new java.lang.Integer(3)",
+        "csharp": "",
+        "shell": ""
+      },
+      {
+        "description": "Int32 with valid string arg",
+        "javascript": "Int32('3')",
+        "python": "int(3)",
+        "java": "new java.lang.Integer(\"3\")",
+        "csharp": ""
+      }
+    ],
+    "Double": [
+      {
+        "description": "Double with number arg",
+        "javascript": "Double(3)",
+        "python": "float(3)",
+        "java": "new java.lang.Double(3)",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))",
+        "shell": ""
+      },
+      {
+        "description": "new Double with number arg",
+        "javascript": "new Double(3)",
+        "python": "float(3)",
+        "java": "new java.lang.Double(3)",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))",
+        "shell": ""
+      },
+      {
+        "description": "Double with valid string arg",
+        "javascript": "Double('3')",
+        "python": "float(3)",
+        "java": "new java.lang.Double(\"3\")",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))"
+      }
+    ],
+    "Long": [
+      {
+        "description": "Long with two number args",
+        "javascript": "new Long(-1, 2147483647)",
+        "python": "Int64(9223372036854775807)",
+        "java": "new java.lang.Long(\"9223372036854775807\")",
+        "csharp": "new BsonInt64(Convert.ToInt32(9223372036854775807))"
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "new Decimal128 with string arg",
+        "javascript": "new Decimal128(Buffer.from('5'))",
+        "python": "Decimal128(Decimal('5'))",
+        "java": "Decimal128.parse(\"5.3E-6175\")",
+        "csharp": "new BsonString(\"5\")"
+      }
+    ],
+    "MinKey/MaxKey": [
+      {
+        "description": "MinKey",
+        "javascript": "MinKey()",
+        "python": "MinKey()",
+        "java": "new MinKey()",
+        "csharp": "BsonMinKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "new MinKey",
+        "javascript": "new MinKey()",
+        "python": "MinKey()",
+        "java": "new MinKey()",
+        "csharp": "BsonMinKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "maxKey",
+        "javascript": "MaxKey()",
+        "python": "MaxKey()",
+        "java": "new MaxKey()",
+        "csharp": "BsonMaxKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "new MaxKey",
+        "javascript": "new MaxKey()",
+        "python": "MaxKey()",
+        "java": "new MaxKey()",
+        "csharp": "BsonMaxKey.Value"
+      }
+    ],
+    "BSONRegExp": [
+      {
+        "description": "new BSONRegExp with string arg",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$')",
+        "python": "RegExp('^[a-z0-9_-]{3,16}$')",
+        "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\")",
+        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\")",
+        "shell": ""
+      },
+      {
+        "description": "new BSONRegExp with string arg and flags",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
+        "python": "RegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
+        "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\", \"imuxls\")",
+        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\", \"imxs\")"
+      }
+    ],
+    "Timestamp": [
+      {
+        "description": "Timestamp with two number args",
+        "javascript": "Timestamp(10, 100)",
+        "python": "Timestamp(10, 100)",
+        "java": "new BSONTimestamp(10, 100)",
+        "csharp": "new BsonTimestamp(10, 100)",
+        "shell": ""
+      },
+      {
+        "description": "new Timestamp with two number args",
+        "javascript": "new Timestamp(10, 100)",
+        "python": "Timestamp(10, 100)",
+        "java": "new BSONTimestamp(10, 100)",
+        "csharp": "new BsonTimestamp(10, 100)"
+      }
+    ],
+    "Document": [
+      {
+        "description": "{x: 1}",
+        "javascript": "{x: 1}",
+        "python": "{'x': 1}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Doc with trailing comma",
+        "javascript": "{x: 1,}",
+        "python": "{'x': 1,}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Doc with array",
+        "javascript": "{x: [1, 2]}",
+        "python": "{'x': [1, 2]}",
+        "java": "new Document().append(\"x\", Arrays.asList(1, 2))",
+        "csharp": "new BsonDocument(\"x\", new BsonArray {1, 2})",
+        "shell": ""
+      },
+      {
+        "description": "Doc with subdoc",
+        "javascript": "{x: {y: 2}}",
+        "python": "{'x': {'y': 2}}",
+        "java": "new Document().append(\"x\", new Document().append(\"y\", 2))",
+        "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", 2))",
+        "shell": ""
+      },
+      {
+        "description": "Object.create()",
+        "javascript": "Object.create({x: 1})",
+        "python": "{'x': 1}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Empty object",
+        "javascript": "{}",
+        "python": "{}",
+        "java": "new Document()",
+        "csharp": "new BsonDocument()",
+        "shell": ""
+      },
+      {
+        "description": "Two items in document",
+        "javascript": "{x: 1, n: 4}",
+        "python": "{'x': 1, 'n': 4}",
+        "java": "new Document().append(\"x\", 1).append(\"n\", 4)",
+        "csharp": "new BsonDocument { { \"x\", 1 }, { \"n\", 4 } }"
+      }
+    ],
+    "Array": [
+      {
+        "description": "[1, 2]",
+        "javascript": "[1, 2]",
+        "python": "[1, 2]",
+        "java": "Arrays.asList(1, 2)",
+        "csharp": "new BsonArray {1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "array with trailing comma",
+        "javascript": "[1, 2,]",
+        "python": "[1, 2]",
+        "java": "Arrays.asList(1, 2)",
+        "csharp": "new BsonArray {1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "Array with subdoc",
+        "javascript": "[1, { settings: 'http2' }]",
+        "python": "[1, {'settings': 'http2'}]",
+        "java": "Arrays.asList(1, new Document().append(\"settings\", \"http2\"))",
+        "csharp": "new BsonArray {1, new BsonDocument(\"settings\", \"http2\")}",
+        "shell": ""
+      },
+      {
+        "description": "Array with subarray",
+        "javascript": "[1, [2, 3]]",
+        "python": "[1, [2, 3]]",
+        "java": "Arrays.asList(1, Arrays.asList(2, 3))",
+        "csharp": "new BsonArray {1, new BsonArray {2, 3}}",
+        "shell": ""
+      },
+      {
+        "description": "Empty array",
+        "javascript": "[]",
+        "python": "[]",
+        "java": "Arrays.asList()",
+        "csharp": "new BsonArray()"
+      }
+    ],
+    "ArrayElision": [
+      {
+        "description": "array with leading elision",
+        "javascript": "[,1, 2,]",
+        "python": "[None, 1, 2]",
+        "java": "Arrays.asList(null, 1, 2)",
+        "csharp": "new BsonArray {BsonNull.Value, 1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "Array with one elision",
+        "javascript": "[,]",
+        "python": "[None]",
+        "java": "Arrays.asList(null)",
+        "csharp": "new BsonArray {BsonNull.Value}",
+        "shell": ""
+      },
+      {
+        "description": "Array with 2 elision",
+        "javascript": "[,,]",
+        "python": "[None, None]",
+        "java": "Arrays.asList(null, null)",
+        "csharp": "new BsonArray {BsonNull.Value, BsonNull.Value}",
+        "shell": ""
+      },
+      {
+        "description": "Array with elision in the middle",
+        "javascript": "[1,,,,2]",
+        "python": "[1, None, None, None, 2]",
+        "java": "Arrays.asList(1, null, null, null, 2)",
+        "csharp": "new BsonArray {1, BsonNull.Value, BsonNull.Value, BsonNull.Value, 2}"
+      }
+    ],
+    "Symbol": [
+      {
+        "description": "Symbol from string",
+        "javascript": "Symbol('2')",
+        "python": "unicode('2', 'utf-8')",
+        "java": "new Symbol(\"2\")",
+        "csharp": "new BsonString(\"2\")",
+        "shell": ""
+      },
+      {
+        "description": "new Symbol from string",
+        "javascript": "new Symbol('2')",
+        "python": "unicode('2', 'utf-8')",
+        "java": "new Symbol(\"2\")",
+        "csharp": "new BsonString(\"2\")"
+      }
+    ]
+  }
+}

--- a/test/json/success/javascript/bson-object-methods.json
+++ b/test/json/success/javascript/bson-object-methods.json
@@ -1,0 +1,458 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "CodeWithScope toJSON",
+        "javascript": "Code('test code', {x: 1}).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", new Document().append(\"x\", 1))",
+        "csharp": ""
+      },
+      {
+        "description": "Code toJSON",
+        "javascript": "Code('test code').toJSON()",
+        "python": "",
+        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", undefined)",
+        "csharp": ""
+      }
+    ],
+    "ObjectId": [
+      {
+        "description": "no arguments toJSON",
+        "javascript": "ObjectId().toJSON()",
+        "python": "",
+        "java": "new ObjectId().toHexString()",
+        "csharp": ""
+      },
+      {
+        "description": "hex arg toJSON",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toJSON()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toHexString()",
+        "csharp": ""
+      },
+      {
+        "description": "no arg toString",
+        "javascript": "ObjectId().toString()",
+        "python": "",
+        "java": "new ObjectId().toString()",
+        "csharp": ""
+      },
+      {
+        "description": "hex arg toString",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toString()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "getTimestamp",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").getTimestamp()",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "ObjectId().equals(ObjectId())",
+        "python": "",
+        "java": "new ObjectId().equals(new ObjectId())",
+        "csharp": ""
+      }
+    ],
+    "Binary": [
+      {
+        "description": "length",
+        "javascript": "Binary(Buffer.from('a string')).length()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).length()",
+        "csharp": ""
+      },
+      {
+        "description": "value",
+        "javascript": "Binary(Buffer.from('a string')).value()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).getData()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Binary(Buffer.from('a string')).toString()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "Binary(Buffer.from('a string')).toJSON()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
+        "csharp": ""
+      }
+    ],
+    "DBRef": [
+      {
+        "description": "toJSON with two args",
+        "javascript": "new DBRef('coll', new ObjectId()).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"\")",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON with three args",
+        "javascript": "new DBRef('coll', new ObjectId(), 'db').toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"db\")",
+        "csharp": ""
+      }
+    ],
+    "Int32": [
+      {
+        "description": "toJSON",
+        "javascript": "Int32(3).toJSON()",
+        "python": "",
+        "java": "new java.lang.Integer(3).intValue()",
+        "csharp": ""
+      },
+      {
+        "description": "valueOf",
+        "javascript": "Int32(3).valueOf()",
+        "python": "",
+        "java": "new java.lang.Integer(3).intValue()",
+        "csharp": ""
+      }
+    ],
+    "Double": [
+      {
+        "description": "toJSON",
+        "javascript": "Double(3).toJSON()",
+        "python": "",
+        "java": "new java.lang.Double(3).doubleValue()",
+        "csharp": ""
+      },
+      {
+        "description": "valueOf",
+        "javascript": "Double(3).valueOf()",
+        "python": "",
+        "java": "new java.lang.Double(3).doubleValue()",
+        "csharp": ""
+      }
+    ],
+    "Long": [
+      {
+        "description": "toJSON",
+        "javascript": "Long(1, 100).toJSON()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toInt",
+        "javascript": "Long(1, 100).toInt()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").intValue()",
+        "csharp": ""
+      },
+      {
+        "description": "toNumber",
+        "javascript": "Long(1, 100).toNumber()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").floatValue()",
+        "csharp": ""
+      },
+      {
+        "description": "toString without radix",
+        "javascript": "Long(1, 100).toString()",
+        "python": "",
+        "java": "java.lang.Long.toString(429496729601)",
+        "csharp": ""
+      },
+      {
+        "description": "toString with radix",
+        "javascript": "Long(1, 100).toString(10)",
+        "python": "",
+        "java": "java.lang.Long.toString(429496729601, 10)",
+        "csharp": ""
+      },
+      {
+        "description": "isZero",
+        "javascript": "Long(1, 100).isZero()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(0))",
+        "csharp": ""
+      },
+      {
+        "description": "isNegative",
+        "javascript": "Long(1, 100).isNegative()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(0)) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "isOdd",
+        "javascript": "Long(1, 100).isOdd()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") % 2 == 0",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "Long(1, 100).equals(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(\"4294967305\"))",
+        "csharp": ""
+      },
+      {
+        "description": "notEquals",
+        "javascript": "Long(1, 100).notEquals(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) != 0",
+        "csharp": ""
+      },
+      {
+        "description": "compare",
+        "javascript": "Long(1, 100).compare(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\"))",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThan",
+        "javascript": "Long(1, 100).greaterThan(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) > 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThanOrEqual",
+        "javascript": "Long(1, 100).greaterThanOrEqual(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) >= 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThan",
+        "javascript": "Long(1, 100).lessThan(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThanOrEqual",
+        "javascript": "Long(1, 100).lessThanOrEqual(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) <= 0",
+        "csharp": ""
+      },
+      {
+        "description": "negate",
+        "javascript": "Long(1, 100).negate())",
+        "python": "",
+        "java": "-new java.lang.Long(\"429496729601\")",
+        "csharp": ""
+      },
+      {
+        "description": "add",
+        "javascript": "Long(1, 100).add(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") + new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "subtract",
+        "javascript": "Long(1, 100).subtract(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") - new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "multiply",
+        "javascript": "Long(1, 100).multiply(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") * new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "div",
+        "javascript": "Long(1, 100).div(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") / new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "modulo",
+        "javascript": "Long(1, 100).modulo(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") % new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "not",
+        "javascript": "Long(1, 100).not()",
+        "python": "",
+        "java": "~new java.lang.Long(\"429496729601\")",
+        "csharp": ""
+      },
+      {
+        "description": "and",
+        "javascript": "Long(1, 100).and(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") & new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "or",
+        "javascript": "Long(1, 100).or(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") | new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "xor",
+        "javascript": "Long(1, 100).xor(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") ^ new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "shiftLeft",
+        "javascript": "Long(1, 100).shiftLeft(10)",
+        "python": "",
+        "java": "java.lang.Long.rotateLeft(new java.lang.Long(\"429496729601\"), 10)",
+        "csharp": ""
+      },
+      {
+        "description": "shiftRight",
+        "javascript": "Long(1, 100).shiftRight(10)",
+        "python": "",
+        "java": "java.lang.Long.rotateRight(new java.lang.Long(\"429496729601\"), 10)",
+        "csharp": ""
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "toString",
+        "javascript": "new Decimal128(Buffer.from('5')).toString()",
+        "python": "",
+        "java": "Decimal128.parse(\"5.3E-6175\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "new Decimal128(Buffer.from('5')).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$numberDecimal\", Decimal128.parse(\"5.3E-6175\").toString())",
+        "csharp": ""
+      }
+    ],
+    "Timestamp": [
+      {
+        "description": "toJSON",
+        "javascript": "Timestamp(1, 100).toJSON()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Timestamp(1, 100).toString()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "Timestamp(1, 100).equals(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).equals(new BSONTimestamp(2, 99))",
+        "csharp": ""
+      },
+      {
+        "description": "compare",
+        "javascript": "Timestamp(1, 100).compare(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99))",
+        "csharp": ""
+      },
+      {
+        "description": "notEquals",
+        "javascript": "Timestamp(1, 100).notEquals(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) != 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThan",
+        "javascript": "Timestamp(1, 100).greaterThan(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) > 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThanOrEqual",
+        "javascript": "Timestamp(1, 100).greaterThanOrEqual(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) >= 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThan",
+        "javascript": "Timestamp(1, 100).lessThan(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThanOrEqual",
+        "javascript": "Timestamp(1, 100).lessThanOrEqual(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) <= 0",
+        "csharp": ""
+      },
+      {
+        "description": "getLowBits",
+        "javascript": "Timestamp(1, 100).getLowBits()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).getTime()",
+        "csharp": ""
+      },
+      {
+        "description": "getHighBits",
+        "javascript": "Timestamp(1, 100).getHighBits()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).getInc()",
+        "csharp": ""
+      }
+    ],
+    "Symbol": [
+      {
+        "description": "valueOf",
+        "javascript": "Symbol('2').valueOf()",
+        "python": "",
+        "java": "new Symbol(\"2\").getSymbol()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Symbol('2').toString()",
+        "python": "",
+        "java": "new Symbol(\"2\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "inspect",
+        "javascript": "Symbol('2').inspect()",
+        "python": "",
+        "java": "new Symbol(\"2\").getSymbol()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "Symbol('2').toJSON()",
+        "python": "",
+        "java": "new Symbol(\"2\").toString()",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/javascript/bson-utils.json
+++ b/test/json/success/javascript/bson-utils.json
@@ -1,0 +1,152 @@
+{
+  "tests": {
+    "ObjectId": [
+      {
+        "description": "createFromHexString",
+        "javascript": "ObjectId.createFromHexString('5ab901c29ee65f5c8550c5b9')",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\")",
+        "csharp": ""
+      },
+      {
+        "description": "createFromTime",
+        "javascript": "ObjectId.createFromTime(1522075031642)",
+        "python": "",
+        "java": "new ObjectId(new java.util.Date(1522075031642))",
+        "csharp": ""
+      },
+      {
+        "description": "isValid",
+        "javascript": "ObjectId.isValid('5ab901c29ee65f5c8550c5b9')",
+        "python": "",
+        "java": "ObjectId.isValid(\"5ab901c29ee65f5c8550c5b9\")",
+        "csharp": ""
+      }
+    ],
+    "Binary": [
+      {
+        "description": "subtype default",
+        "javascript": "Binary.SUBTYPE_DEFAULT",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.BINARY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype function",
+        "javascript": "Binary.SUBTYPE_FUNCTION",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.FUNCTION",
+        "csharp": ""
+      },
+      {
+        "description": "subtype byte array",
+        "javascript": "Binary.SUBTYPE_BYTE_ARRAY",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.OLD_BINARY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype uuid old",
+        "javascript": "Binary.SUBTYPE_UUID_OLD",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.UUID_LEGACY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype uuid",
+        "javascript": "Binary.SUBTYPE_UUID",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.UUID",
+        "csharp": ""
+      },
+      {
+        "description": "subtype md5",
+        "javascript": "Binary.SUBTYPE_MD5",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.MD5",
+        "csharp": ""
+      },
+      {
+        "description": "subtype udef",
+        "javascript": "Binary.SUBTYPE_USER_DEFINED",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.USER_DEFINED",
+        "csharp": ""
+      }
+    ],
+    "Long": [
+      {
+        "description": "MAX_VALUE",
+        "javascript": "Long.MAX_VALUE",
+        "python": "",
+        "java": "java.lang.Long.MAX_VALUE",
+        "csharp": ""
+      },
+      {
+        "description": "MIN_VALUE",
+        "javascript": "Long.MIN_VALUE",
+        "python": "",
+        "java": "java.lang.Long.MIN_VALUE",
+        "csharp": ""
+      },
+      {
+        "description": "ZERO",
+        "javascript": "Long.ZERO",
+        "python": "",
+        "java": "new java.lang.Long(0)",
+        "csharp": ""
+      },
+      {
+        "description": "ONE",
+        "javascript": "Long.ONE",
+        "python": "",
+        "java": "new java.lang.Long(1)",
+        "csharp": ""
+      },
+      {
+        "description": "NEG_ONE",
+        "javascript": "Long.NEG_ONE",
+        "python": "",
+        "java": "new java.lang.Long(-1)",
+        "csharp": ""
+      },
+      {
+        "description": "fromInt",
+        "javascript": "Long.fromInt(5)",
+        "python": "",
+        "java": "new java.lang.Long(5)",
+        "csharp": ""
+      },
+      {
+        "description": "fromString without radix",
+        "javascript": "Long.fromString('5')",
+        "python": "",
+        "java": "java.lang.Long.parseLong(\"5\")",
+        "csharp": ""
+      },
+      {
+        "description": "fromString with radix",
+        "javascript": "Long.fromString('5', 10)",
+        "python": "",
+        "java": "java.lang.Long.parseLong(\"5\", 10)",
+        "csharp": ""
+      },
+      {
+        "description": "fromBits",
+        "javascript": "Long.fromBits(-1, 2147483647)",
+        "python": "",
+        "java": "new java.lang.Long(\"9223372036854775807\")",
+        "csharp": ""
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "fromString",
+        "javascript": "Decimal128.fromString(\"5\")",
+        "python": "",
+        "java": "Decimal128.parse(\"5\")",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/javascript/js-constructors.json
+++ b/test/json/success/javascript/js-constructors.json
@@ -1,0 +1,259 @@
+{
+  "tests": {
+    "math": [
+      {
+        "description": "simple addition",
+        "javascript": "2+5",
+        "python": "2+5",
+        "java": "2+5",
+        "csharp": "2+5"
+      },
+      {
+        "description": "multiplication and division",
+        "javascript": "2+(4*36)/3",
+        "python": "2+(4*36)/3",
+        "java": "2+(4*36)/3",
+        "csharp": "2+(4*36)/3"
+      }
+    ],
+    "Number": [
+      {
+        "description": "Number with number arg",
+        "javascript": "new Number(2)",
+        "python": "int(2)",
+        "java": "new java.lang.Integer(2)",
+        "csharp": "new int(2)"
+      },
+      {
+        "description": "Number with valid string arg",
+        "javascript": "new Number('2')",
+        "python": "int(2)",
+        "java": "new java.lang.Integer(\"2\")",
+        "csharp": "new int(2)"
+      }
+    ],
+    "literals": [
+      {
+        "description": "Integer 2",
+        "javascript": "2",
+        "python": "2",
+        "java": "2",
+        "csharp": "2"
+      },
+      {
+        "description": "Decimal 2.001",
+        "javascript": "2.001",
+        "python": "2.001",
+        "java": "2.001",
+        "csharp": "2.001"
+      },
+      {
+        "description": "Hex number caps",
+        "javascript": "0X123ABC",
+        "python": "0X123ABC",
+        "java": "0X123ABC",
+        "csharp": "0X123ABC"
+      },
+      {
+        "description": "Hex number lower",
+        "javascript": "0x123abc",
+        "python": "0x123abc",
+        "java": "0x123abc",
+        "csharp": "0x123abc"
+      },
+      {
+        "description": "Octal 0-prefix number",
+        "javascript": "01234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "1234567"
+      },
+      {
+        "description": "Octal 00-prefix number",
+        "javascript": "001234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "1234567"
+      },
+      {
+        "description": "Octal 0o-prefix number",
+        "javascript": "0o1234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "0"
+      },
+      {
+        "description": "Octal 0O-prefix number",
+        "javascript": "0o1234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "0"
+      },
+      {
+        "description": "Single-quote string",
+        "javascript": "'string'",
+        "python": "'string'",
+        "java": "\"string\"",
+        "csharp": "\"string\""
+      },
+      {
+        "description": "Double-quote string",
+        "javascript": "\"string\"",
+        "python": "'string'",
+        "java": "\"string\"",
+        "csharp": "\"string\""
+      },
+      {
+        "description": "null",
+        "javascript": "null",
+        "python": "None",
+        "java": "null",
+        "csharp": "BsonNull.Value"
+      },
+      {
+        "description": "undefined",
+        "javascript": "undefined",
+        "python": "None",
+        "java": "null",
+        "csharp": "BsonUndefined.Value"
+      },
+      {
+        "description": "true",
+        "javascript": "true",
+        "python": "True",
+        "java": "true",
+        "csharp": "true"
+      },
+      {
+        "description": "false",
+        "javascript": "false",
+        "python": "False",
+        "java": "false",
+        "csharp": "false"
+      }
+    ],
+    "Date": [
+      {
+        "description": "new Date with ISO String",
+        "javascript": "new Date('December 17, 1995 03:24:00Z')",
+        "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819170640000)",
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
+      },
+      {
+        "description": "new Date with UTC number",
+        "javascript": "new Date(819167040000)",
+        "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819167040000)",
+        "csharp": "new DateTime(1995, 12, 17, 2, 24, 0)"
+      },
+      {
+        "description": "Current date",
+        "javascript": "new Date()",
+        "python": "datetime.datetime.utcnow().date()",
+        "java": "new java.util.Date()",
+        "csharp": "DateTime.Now"
+      },
+      {
+        "description": "Date from year, month and day",
+        "javascript": "new Date(1995, 11, 17)",
+        "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819158400000)",
+        "csharp": "new DateTime(1995, 12, 17, 0, 0, 0)"
+      },
+      {
+        "description": "Date from year, month, day, hour, min and sec",
+        "javascript": "new Date(1995, 11, 17, 3, 24, 0)",
+        "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819170640000)",
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
+      }
+    ],
+    "RegExp": [
+      {
+        "description": "empty RegExp",
+        "javascript": "RegExp('')",
+        "python": "re.compile(r\"(?:)\")",
+        "java": "Pattern.compile(\"(?:)\")",
+        "csharp": ""
+      },
+      {
+        "description": "RegExp without options",
+        "javascript": "RegExp('abc')",
+        "python": "re.compile(r\"abc\")",
+        "java": "Pattern.compile(\"abc\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with im flags as args",
+        "javascript": "new RegExp('ab+c', 'im')",
+        "python": "re.compile(r\"ab+c(?im)\")",
+        "java": "Pattern.compile(\"ab+c(?im)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with ig flags as args",
+        "javascript": "new RegExp('ab+c', 'ig')",
+        "python": "re.compile(r\"ab+c(?is)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with forward slash",
+        "javascript": "new RegExp('ab/cd')",
+        "python": "re.compile(r\"ab\\/cd\")",
+        "java": "Pattern.compile(\"ab\\/cd\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with escaped double quote",
+        "javascript": "new RegExp('ab\\\"ab')",
+        "python": "re.compile(r\"ab\\\"ab\")",
+        "java": "Pattern.compile(\"ab\\\"ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with nonescaped double quote",
+        "javascript": "new RegExp('ab\"ab')",
+        "python": "re.compile(r\"ab\\\"ab\")",
+        "java": "Pattern.compile(\"ab\\\"ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with escaped single quote",
+        "javascript": "new RegExp('ab\\'ab')",
+        "python": "re.compile(r\"ab'ab\")",
+        "java": "Pattern.compile(\"ab'ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with nonescaped single quote",
+        "javascript": "new RegExp(\"ab'ab\")",
+        "python": "re.compile(r\"ab'ab\")",
+        "java": "Pattern.compile(\"ab'ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with newline",
+        "javascript": "new RegExp(\"\\\\n\")",
+        "python": "re.compile(r\"\\\\n\")",
+        "java": "Pattern.compile(\"\\\\n\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex literal with ig flags",
+        "javascript": "/ab+c/ig",
+        "python": "re.compile(r\"ab+c(?is)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with regex literal arg",
+        "javascript": "new RegExp(/ab+c/, 'i')",
+        "python": "re.compile(r\"ab+c(?i)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/javascript/js-utils.json
+++ b/test/json/success/javascript/js-utils.json
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "Date": [
+      {
+        "description": "Current time",
+        "javascript": "Date.now()",
+        "python": "datetime.datetime.utcnow()",
+        "java": "new java.util.Date()",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/shell/bson-constructors.json
+++ b/test/json/success/shell/bson-constructors.json
@@ -1,0 +1,374 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "new Code with string arg",
+        "javascript": "new Code('some code')",
+        "python": "Code('some code')",
+        "java": "new Code(\"some code\")",
+        "csharp": "new BsonJavaScript(@\"some code\")",
+        "shell": "Code('some code')"
+      },
+      {
+        "description": "Code with string code",
+        "javascript": "Code('some code')",
+        "python": "Code('some code')",
+        "java": "new Code(\"some code\")",
+        "csharp": "new BsonJavaScript(@\"some code\")",
+        "shell": "Code('some code')"
+      },
+      {
+        "description": "Code with string code and object scope",
+        "javascript": "Code('string', {x: 1})",
+        "python": "Code('string', {'x': 1})",
+        "java": "new CodeWithScope(\"string\", new Document().append(\"x\", 1))",
+        "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", 1))",
+        "shell": "Code('string', {x: 1})"
+      },
+      {
+        "description": "Code with function code",
+        "javascript": "Code(function(test) { console.log(test); })",
+        "python": "Code('function(test){console.log(test);}')",
+        "java": "new Code(\"function(test){console.log(test);}\")",
+        "csharp": "new BsonJavaScript(@\"function(test){console.log(test);}\")",
+        "shell": "Code('function(test){console.log(test);}')"
+      },
+      {
+        "description": "Code with where code",
+        "javascript": "new Code('this.a > i', { i: 1 })",
+        "python": "Code('this.a > i', {'i': 1})",
+        "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", 1))",
+        "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", 1))",
+        "shell": "Code('this.a > i', {i: 1})"
+      }
+    ],
+    "ObjectId": [
+      {
+        "description": "ObjectId with no arg",
+        "javascript": "ObjectId()",
+        "python": "ObjectId()",
+        "java": "new ObjectId()",
+        "csharp": "new BsonObjectId()",
+        "shell": "ObjectId()"
+      },
+      {
+        "description": "new ObjectId with no arg",
+        "javascript": "new ObjectId()",
+        "python": "ObjectId()",
+        "java": "new ObjectId()",
+        "csharp": "new BsonObjectId()",
+        "shell": "new ObjectId()"
+      },
+      {
+        "description": "ObjectId with hex string arg",
+        "javascript": "ObjectId('5a7382114ec1f67ae445f778')",
+        "python": "ObjectId('5a7382114ec1f67ae445f778')",
+        "java": "new ObjectId(\"5a7382114ec1f67ae445f778\")",
+        "csharp": "new BsonObjectId(\"5a7382114ec1f67ae445f778\")",
+        "shell": "new ObjectId('5a7382114ec1f67ae445f778')"
+      }
+    ],
+    "Binary": [
+      {
+        "description": "new Binary with (ascii buffer, UUID subtype enum) args",
+        "javascript": "new Binary(Buffer.from(\"1234\"), Binary.SUBTYPE_UUID)",
+        "python": "Binary(bytes('1234', 'utf-8'), bson.binary.UUID_SUBTYPE)",
+        "java": "new Binary(org.bson.BsonBinarySubType.UUID, \"1234\".getBytes(\"UTF-8\"))",
+        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"), BsonBinarySubType.UuidStandard)",
+        "shell": "new BinData(4, '1234')"
+      }
+    ],
+    "DBRef": [
+      {
+        "description": "new DBRef with (string, ObjectID) args",
+        "javascript": "new DBRef('coll', new ObjectId())",
+        "python": "DBRef('coll', ObjectId())",
+        "java": "new DBRef(\"coll\", new ObjectId())",
+        "csharp": "DBRef(\"coll\", new BsonObjectId())",
+        "shell": ""
+      },
+      {
+        "description": "new DBRef with (string, ObjectId, string) args",
+        "javascript": "new DBRef('coll', ObjectId(), 'db')",
+        "python": "DBRef('coll', ObjectId(), 'db')",
+        "java": "new DBRef(\"coll\", new ObjectId(), \"db\")",
+        "csharp": "DBRef(\"coll\", new BsonObjectId(), \"db\")"
+      }
+    ],
+    "Int32": [
+      {
+        "description": "Int32 with number arg",
+        "javascript": "Int32(3)",
+        "python": "int(3)",
+        "java": "new java.lang.Integer(3)",
+        "csharp": "",
+        "shell": ""
+      },
+      {
+        "description": "Int32 with valid string arg",
+        "javascript": "Int32('3')",
+        "python": "int(3)",
+        "java": "new java.lang.Integer(\"3\")",
+        "csharp": ""
+      }
+    ],
+    "Double": [
+      {
+        "description": "Double with number arg",
+        "javascript": "Double(3)",
+        "python": "float(3)",
+        "java": "new java.lang.Double(3)",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))",
+        "shell": ""
+      },
+      {
+        "description": "new Double with number arg",
+        "javascript": "new Double(3)",
+        "python": "float(3)",
+        "java": "new java.lang.Double(3)",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))",
+        "shell": ""
+      },
+      {
+        "description": "Double with valid string arg",
+        "javascript": "Double('3')",
+        "python": "float(3)",
+        "java": "new java.lang.Double(\"3\")",
+        "csharp": "new BsonDouble(Convert.ToDouble(\"3\"))"
+      }
+    ],
+    "Long": [
+      {
+        "description": "Long with two number args",
+        "javascript": "new Long(-1, 2147483647)",
+        "python": "Int64(9223372036854775807)",
+        "java": "new java.lang.Long(\"9223372036854775807\")",
+        "csharp": "new BsonInt64(Convert.ToInt32(9223372036854775807))"
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "new Decimal128 with string arg",
+        "javascript": "new Decimal128(Buffer.from('5'))",
+        "python": "Decimal128(Decimal('5'))",
+        "java": "Decimal128.parse(\"5.3E-6175\")",
+        "csharp": "new BsonString(\"5\")"
+      }
+    ],
+    "MinKey/MaxKey": [
+      {
+        "description": "MinKey",
+        "javascript": "MinKey()",
+        "python": "MinKey()",
+        "java": "new MinKey()",
+        "csharp": "BsonMinKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "new MinKey",
+        "javascript": "new MinKey()",
+        "python": "MinKey()",
+        "java": "new MinKey()",
+        "csharp": "BsonMinKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "maxKey",
+        "javascript": "MaxKey()",
+        "python": "MaxKey()",
+        "java": "new MaxKey()",
+        "csharp": "BsonMaxKey.Value",
+        "shell": ""
+      },
+      {
+        "description": "new MaxKey",
+        "javascript": "new MaxKey()",
+        "python": "MaxKey()",
+        "java": "new MaxKey()",
+        "csharp": "BsonMaxKey.Value"
+      }
+    ],
+    "BSONRegExp": [
+      {
+        "description": "new BSONRegExp with string arg",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$')",
+        "python": "RegExp('^[a-z0-9_-]{3,16}$')",
+        "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\")",
+        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\")",
+        "shell": ""
+      },
+      {
+        "description": "new BSONRegExp with string arg and flags",
+        "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
+        "python": "RegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
+        "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\", \"imuxls\")",
+        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\", \"imxs\")"
+      }
+    ],
+    "Timestamp": [
+      {
+        "description": "Timestamp with two number args",
+        "javascript": "Timestamp(10, 100)",
+        "python": "Timestamp(10, 100)",
+        "java": "new BSONTimestamp(10, 100)",
+        "csharp": "new BsonTimestamp(10, 100)",
+        "shell": ""
+      },
+      {
+        "description": "new Timestamp with two number args",
+        "javascript": "new Timestamp(10, 100)",
+        "python": "Timestamp(10, 100)",
+        "java": "new BSONTimestamp(10, 100)",
+        "csharp": "new BsonTimestamp(10, 100)"
+      }
+    ],
+    "Document": [
+      {
+        "description": "{x: 1}",
+        "javascript": "{x: 1}",
+        "python": "{'x': 1}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Doc with trailing comma",
+        "javascript": "{x: 1,}",
+        "python": "{'x': 1,}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Doc with array",
+        "javascript": "{x: [1, 2]}",
+        "python": "{'x': [1, 2]}",
+        "java": "new Document().append(\"x\", Arrays.asList(1, 2))",
+        "csharp": "new BsonDocument(\"x\", new BsonArray {1, 2})",
+        "shell": ""
+      },
+      {
+        "description": "Doc with subdoc",
+        "javascript": "{x: {y: 2}}",
+        "python": "{'x': {'y': 2}}",
+        "java": "new Document().append(\"x\", new Document().append(\"y\", 2))",
+        "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", 2))",
+        "shell": ""
+      },
+      {
+        "description": "Object.create()",
+        "javascript": "Object.create({x: 1})",
+        "python": "{'x': 1}",
+        "java": "new Document().append(\"x\", 1)",
+        "csharp": "new BsonDocument(\"x\", 1)",
+        "shell": ""
+      },
+      {
+        "description": "Empty object",
+        "javascript": "{}",
+        "python": "{}",
+        "java": "new Document()",
+        "csharp": "new BsonDocument()",
+        "shell": ""
+      },
+      {
+        "description": "Two items in document",
+        "javascript": "{x: 1, n: 4}",
+        "python": "{'x': 1, 'n': 4}",
+        "java": "new Document().append(\"x\", 1).append(\"n\", 4)",
+        "csharp": "new BsonDocument { { \"x\", 1 }, { \"n\", 4 } }"
+      }
+    ],
+    "Array": [
+      {
+        "description": "[1, 2]",
+        "javascript": "[1, 2]",
+        "python": "[1, 2]",
+        "java": "Arrays.asList(1, 2)",
+        "csharp": "new BsonArray {1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "array with trailing comma",
+        "javascript": "[1, 2,]",
+        "python": "[1, 2]",
+        "java": "Arrays.asList(1, 2)",
+        "csharp": "new BsonArray {1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "Array with subdoc",
+        "javascript": "[1, { settings: 'http2' }]",
+        "python": "[1, {'settings': 'http2'}]",
+        "java": "Arrays.asList(1, new Document().append(\"settings\", \"http2\"))",
+        "csharp": "new BsonArray {1, new BsonDocument(\"settings\", \"http2\")}",
+        "shell": ""
+      },
+      {
+        "description": "Array with subarray",
+        "javascript": "[1, [2, 3]]",
+        "python": "[1, [2, 3]]",
+        "java": "Arrays.asList(1, Arrays.asList(2, 3))",
+        "csharp": "new BsonArray {1, new BsonArray {2, 3}}",
+        "shell": ""
+      },
+      {
+        "description": "Empty array",
+        "javascript": "[]",
+        "python": "[]",
+        "java": "Arrays.asList()",
+        "csharp": "new BsonArray()"
+      }
+    ],
+    "ArrayElision": [
+      {
+        "description": "array with leading elision",
+        "javascript": "[,1, 2,]",
+        "python": "[None, 1, 2]",
+        "java": "Arrays.asList(null, 1, 2)",
+        "csharp": "new BsonArray {BsonNull.Value, 1, 2}",
+        "shell": ""
+      },
+      {
+        "description": "Array with one elision",
+        "javascript": "[,]",
+        "python": "[None]",
+        "java": "Arrays.asList(null)",
+        "csharp": "new BsonArray {BsonNull.Value}",
+        "shell": ""
+      },
+      {
+        "description": "Array with 2 elision",
+        "javascript": "[,,]",
+        "python": "[None, None]",
+        "java": "Arrays.asList(null, null)",
+        "csharp": "new BsonArray {BsonNull.Value, BsonNull.Value}",
+        "shell": ""
+      },
+      {
+        "description": "Array with elision in the middle",
+        "javascript": "[1,,,,2]",
+        "python": "[1, None, None, None, 2]",
+        "java": "Arrays.asList(1, null, null, null, 2)",
+        "csharp": "new BsonArray {1, BsonNull.Value, BsonNull.Value, BsonNull.Value, 2}"
+      }
+    ],
+    "Symbol": [
+      {
+        "description": "Symbol from string",
+        "javascript": "Symbol('2')",
+        "python": "unicode('2', 'utf-8')",
+        "java": "new Symbol(\"2\")",
+        "csharp": "new BsonString(\"2\")",
+        "shell": ""
+      },
+      {
+        "description": "new Symbol from string",
+        "javascript": "new Symbol('2')",
+        "python": "unicode('2', 'utf-8')",
+        "java": "new Symbol(\"2\")",
+        "csharp": "new BsonString(\"2\")"
+      }
+    ]
+  }
+}

--- a/test/json/success/shell/bson-object-methods.json
+++ b/test/json/success/shell/bson-object-methods.json
@@ -1,0 +1,458 @@
+{
+  "tests": {
+    "Code": [
+      {
+        "description": "CodeWithScope toJSON",
+        "javascript": "Code('test code', {x: 1}).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", new Document().append(\"x\", 1))",
+        "csharp": ""
+      },
+      {
+        "description": "Code toJSON",
+        "javascript": "Code('test code').toJSON()",
+        "python": "",
+        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", undefined)",
+        "csharp": ""
+      }
+    ],
+    "ObjectId": [
+      {
+        "description": "no arguments toJSON",
+        "javascript": "ObjectId().toJSON()",
+        "python": "",
+        "java": "new ObjectId().toHexString()",
+        "csharp": ""
+      },
+      {
+        "description": "hex arg toJSON",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toJSON()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toHexString()",
+        "csharp": ""
+      },
+      {
+        "description": "no arg toString",
+        "javascript": "ObjectId().toString()",
+        "python": "",
+        "java": "new ObjectId().toString()",
+        "csharp": ""
+      },
+      {
+        "description": "hex arg toString",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toString()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "getTimestamp",
+        "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").getTimestamp()",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "ObjectId().equals(ObjectId())",
+        "python": "",
+        "java": "new ObjectId().equals(new ObjectId())",
+        "csharp": ""
+      }
+    ],
+    "Binary": [
+      {
+        "description": "length",
+        "javascript": "Binary(Buffer.from('a string')).length()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).length()",
+        "csharp": ""
+      },
+      {
+        "description": "value",
+        "javascript": "Binary(Buffer.from('a string')).value()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).getData()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Binary(Buffer.from('a string')).toString()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "Binary(Buffer.from('a string')).toJSON()",
+        "python": "",
+        "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
+        "csharp": ""
+      }
+    ],
+    "DBRef": [
+      {
+        "description": "toJSON with two args",
+        "javascript": "new DBRef('coll', new ObjectId()).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"\")",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON with three args",
+        "javascript": "new DBRef('coll', new ObjectId(), 'db').toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$ref\", \"coll\").append(\"$id\", new ObjectId()).append(\"$db\", \"db\")",
+        "csharp": ""
+      }
+    ],
+    "Int32": [
+      {
+        "description": "toJSON",
+        "javascript": "Int32(3).toJSON()",
+        "python": "",
+        "java": "new java.lang.Integer(3).intValue()",
+        "csharp": ""
+      },
+      {
+        "description": "valueOf",
+        "javascript": "Int32(3).valueOf()",
+        "python": "",
+        "java": "new java.lang.Integer(3).intValue()",
+        "csharp": ""
+      }
+    ],
+    "Double": [
+      {
+        "description": "toJSON",
+        "javascript": "Double(3).toJSON()",
+        "python": "",
+        "java": "new java.lang.Double(3).doubleValue()",
+        "csharp": ""
+      },
+      {
+        "description": "valueOf",
+        "javascript": "Double(3).valueOf()",
+        "python": "",
+        "java": "new java.lang.Double(3).doubleValue()",
+        "csharp": ""
+      }
+    ],
+    "Long": [
+      {
+        "description": "toJSON",
+        "javascript": "Long(1, 100).toJSON()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toInt",
+        "javascript": "Long(1, 100).toInt()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").intValue()",
+        "csharp": ""
+      },
+      {
+        "description": "toNumber",
+        "javascript": "Long(1, 100).toNumber()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").floatValue()",
+        "csharp": ""
+      },
+      {
+        "description": "toString without radix",
+        "javascript": "Long(1, 100).toString()",
+        "python": "",
+        "java": "java.lang.Long.toString(429496729601)",
+        "csharp": ""
+      },
+      {
+        "description": "toString with radix",
+        "javascript": "Long(1, 100).toString(10)",
+        "python": "",
+        "java": "java.lang.Long.toString(429496729601, 10)",
+        "csharp": ""
+      },
+      {
+        "description": "isZero",
+        "javascript": "Long(1, 100).isZero()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(0))",
+        "csharp": ""
+      },
+      {
+        "description": "isNegative",
+        "javascript": "Long(1, 100).isNegative()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(0)) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "isOdd",
+        "javascript": "Long(1, 100).isOdd()",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") % 2 == 0",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "Long(1, 100).equals(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(\"4294967305\"))",
+        "csharp": ""
+      },
+      {
+        "description": "notEquals",
+        "javascript": "Long(1, 100).notEquals(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) != 0",
+        "csharp": ""
+      },
+      {
+        "description": "compare",
+        "javascript": "Long(1, 100).compare(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\"))",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThan",
+        "javascript": "Long(1, 100).greaterThan(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) > 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThanOrEqual",
+        "javascript": "Long(1, 100).greaterThanOrEqual(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) >= 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThan",
+        "javascript": "Long(1, 100).lessThan(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThanOrEqual",
+        "javascript": "Long(1, 100).lessThanOrEqual(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) <= 0",
+        "csharp": ""
+      },
+      {
+        "description": "negate",
+        "javascript": "Long(1, 100).negate())",
+        "python": "",
+        "java": "-new java.lang.Long(\"429496729601\")",
+        "csharp": ""
+      },
+      {
+        "description": "add",
+        "javascript": "Long(1, 100).add(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") + new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "subtract",
+        "javascript": "Long(1, 100).subtract(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") - new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "multiply",
+        "javascript": "Long(1, 100).multiply(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") * new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "div",
+        "javascript": "Long(1, 100).div(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") / new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "modulo",
+        "javascript": "Long(1, 100).modulo(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") % new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "not",
+        "javascript": "Long(1, 100).not()",
+        "python": "",
+        "java": "~new java.lang.Long(\"429496729601\")",
+        "csharp": ""
+      },
+      {
+        "description": "and",
+        "javascript": "Long(1, 100).and(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") & new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "or",
+        "javascript": "Long(1, 100).or(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") | new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "xor",
+        "javascript": "Long(1, 100).xor(Long(9, 1))",
+        "python": "",
+        "java": "new java.lang.Long(\"429496729601\") ^ new java.lang.Long(\"4294967305\")",
+        "csharp": ""
+      },
+      {
+        "description": "shiftLeft",
+        "javascript": "Long(1, 100).shiftLeft(10)",
+        "python": "",
+        "java": "java.lang.Long.rotateLeft(new java.lang.Long(\"429496729601\"), 10)",
+        "csharp": ""
+      },
+      {
+        "description": "shiftRight",
+        "javascript": "Long(1, 100).shiftRight(10)",
+        "python": "",
+        "java": "java.lang.Long.rotateRight(new java.lang.Long(\"429496729601\"), 10)",
+        "csharp": ""
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "toString",
+        "javascript": "new Decimal128(Buffer.from('5')).toString()",
+        "python": "",
+        "java": "Decimal128.parse(\"5.3E-6175\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "new Decimal128(Buffer.from('5')).toJSON()",
+        "python": "",
+        "java": "new Document().append(\"$numberDecimal\", Decimal128.parse(\"5.3E-6175\").toString())",
+        "csharp": ""
+      }
+    ],
+    "Timestamp": [
+      {
+        "description": "toJSON",
+        "javascript": "Timestamp(1, 100).toJSON()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Timestamp(1, 100).toString()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).toString()",
+        "csharp": ""
+      },
+      {
+        "description": "equals",
+        "javascript": "Timestamp(1, 100).equals(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).equals(new BSONTimestamp(2, 99))",
+        "csharp": ""
+      },
+      {
+        "description": "compare",
+        "javascript": "Timestamp(1, 100).compare(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99))",
+        "csharp": ""
+      },
+      {
+        "description": "notEquals",
+        "javascript": "Timestamp(1, 100).notEquals(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) != 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThan",
+        "javascript": "Timestamp(1, 100).greaterThan(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) > 0",
+        "csharp": ""
+      },
+      {
+        "description": "greaterThanOrEqual",
+        "javascript": "Timestamp(1, 100).greaterThanOrEqual(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) >= 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThan",
+        "javascript": "Timestamp(1, 100).lessThan(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) < 0",
+        "csharp": ""
+      },
+      {
+        "description": "lessThanOrEqual",
+        "javascript": "Timestamp(1, 100).lessThanOrEqual(Timestamp(2, 99))",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) <= 0",
+        "csharp": ""
+      },
+      {
+        "description": "getLowBits",
+        "javascript": "Timestamp(1, 100).getLowBits()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).getTime()",
+        "csharp": ""
+      },
+      {
+        "description": "getHighBits",
+        "javascript": "Timestamp(1, 100).getHighBits()",
+        "python": "",
+        "java": "new BSONTimestamp(1, 100).getInc()",
+        "csharp": ""
+      }
+    ],
+    "Symbol": [
+      {
+        "description": "valueOf",
+        "javascript": "Symbol('2').valueOf()",
+        "python": "",
+        "java": "new Symbol(\"2\").getSymbol()",
+        "csharp": ""
+      },
+      {
+        "description": "toString",
+        "javascript": "Symbol('2').toString()",
+        "python": "",
+        "java": "new Symbol(\"2\").toString()",
+        "csharp": ""
+      },
+      {
+        "description": "inspect",
+        "javascript": "Symbol('2').inspect()",
+        "python": "",
+        "java": "new Symbol(\"2\").getSymbol()",
+        "csharp": ""
+      },
+      {
+        "description": "toJSON",
+        "javascript": "Symbol('2').toJSON()",
+        "python": "",
+        "java": "new Symbol(\"2\").toString()",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/shell/bson-utils.json
+++ b/test/json/success/shell/bson-utils.json
@@ -1,0 +1,152 @@
+{
+  "tests": {
+    "ObjectId": [
+      {
+        "description": "createFromHexString",
+        "javascript": "ObjectId.createFromHexString('5ab901c29ee65f5c8550c5b9')",
+        "python": "",
+        "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\")",
+        "csharp": ""
+      },
+      {
+        "description": "createFromTime",
+        "javascript": "ObjectId.createFromTime(1522075031642)",
+        "python": "",
+        "java": "new ObjectId(new java.util.Date(1522075031642))",
+        "csharp": ""
+      },
+      {
+        "description": "isValid",
+        "javascript": "ObjectId.isValid('5ab901c29ee65f5c8550c5b9')",
+        "python": "",
+        "java": "ObjectId.isValid(\"5ab901c29ee65f5c8550c5b9\")",
+        "csharp": ""
+      }
+    ],
+    "Binary": [
+      {
+        "description": "subtype default",
+        "javascript": "Binary.SUBTYPE_DEFAULT",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.BINARY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype function",
+        "javascript": "Binary.SUBTYPE_FUNCTION",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.FUNCTION",
+        "csharp": ""
+      },
+      {
+        "description": "subtype byte array",
+        "javascript": "Binary.SUBTYPE_BYTE_ARRAY",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.OLD_BINARY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype uuid old",
+        "javascript": "Binary.SUBTYPE_UUID_OLD",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.UUID_LEGACY",
+        "csharp": ""
+      },
+      {
+        "description": "subtype uuid",
+        "javascript": "Binary.SUBTYPE_UUID",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.UUID",
+        "csharp": ""
+      },
+      {
+        "description": "subtype md5",
+        "javascript": "Binary.SUBTYPE_MD5",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.MD5",
+        "csharp": ""
+      },
+      {
+        "description": "subtype udef",
+        "javascript": "Binary.SUBTYPE_USER_DEFINED",
+        "python": "",
+        "java": "org.bson.BsonBinarySubType.USER_DEFINED",
+        "csharp": ""
+      }
+    ],
+    "Long": [
+      {
+        "description": "MAX_VALUE",
+        "javascript": "Long.MAX_VALUE",
+        "python": "",
+        "java": "java.lang.Long.MAX_VALUE",
+        "csharp": ""
+      },
+      {
+        "description": "MIN_VALUE",
+        "javascript": "Long.MIN_VALUE",
+        "python": "",
+        "java": "java.lang.Long.MIN_VALUE",
+        "csharp": ""
+      },
+      {
+        "description": "ZERO",
+        "javascript": "Long.ZERO",
+        "python": "",
+        "java": "new java.lang.Long(0)",
+        "csharp": ""
+      },
+      {
+        "description": "ONE",
+        "javascript": "Long.ONE",
+        "python": "",
+        "java": "new java.lang.Long(1)",
+        "csharp": ""
+      },
+      {
+        "description": "NEG_ONE",
+        "javascript": "Long.NEG_ONE",
+        "python": "",
+        "java": "new java.lang.Long(-1)",
+        "csharp": ""
+      },
+      {
+        "description": "fromInt",
+        "javascript": "Long.fromInt(5)",
+        "python": "",
+        "java": "new java.lang.Long(5)",
+        "csharp": ""
+      },
+      {
+        "description": "fromString without radix",
+        "javascript": "Long.fromString('5')",
+        "python": "",
+        "java": "java.lang.Long.parseLong(\"5\")",
+        "csharp": ""
+      },
+      {
+        "description": "fromString with radix",
+        "javascript": "Long.fromString('5', 10)",
+        "python": "",
+        "java": "java.lang.Long.parseLong(\"5\", 10)",
+        "csharp": ""
+      },
+      {
+        "description": "fromBits",
+        "javascript": "Long.fromBits(-1, 2147483647)",
+        "python": "",
+        "java": "new java.lang.Long(\"9223372036854775807\")",
+        "csharp": ""
+      }
+    ],
+    "Decimal128": [
+      {
+        "description": "fromString",
+        "javascript": "Decimal128.fromString(\"5\")",
+        "python": "",
+        "java": "Decimal128.parse(\"5\")",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/shell/js-constructors.json
+++ b/test/json/success/shell/js-constructors.json
@@ -1,0 +1,259 @@
+{
+  "tests": {
+    "math": [
+      {
+        "description": "simple addition",
+        "javascript": "2+5",
+        "python": "2+5",
+        "java": "2+5",
+        "csharp": "2+5"
+      },
+      {
+        "description": "multiplication and division",
+        "javascript": "2+(4*36)/3",
+        "python": "2+(4*36)/3",
+        "java": "2+(4*36)/3",
+        "csharp": "2+(4*36)/3"
+      }
+    ],
+    "Number": [
+      {
+        "description": "Number with number arg",
+        "javascript": "new Number(2)",
+        "python": "int(2)",
+        "java": "new java.lang.Integer(2)",
+        "csharp": "new int(2)"
+      },
+      {
+        "description": "Number with valid string arg",
+        "javascript": "new Number('2')",
+        "python": "int(2)",
+        "java": "new java.lang.Integer(\"2\")",
+        "csharp": "new int(2)"
+      }
+    ],
+    "literals": [
+      {
+        "description": "Integer 2",
+        "javascript": "2",
+        "python": "2",
+        "java": "2",
+        "csharp": "2"
+      },
+      {
+        "description": "Decimal 2.001",
+        "javascript": "2.001",
+        "python": "2.001",
+        "java": "2.001",
+        "csharp": "2.001"
+      },
+      {
+        "description": "Hex number caps",
+        "javascript": "0X123ABC",
+        "python": "0X123ABC",
+        "java": "0X123ABC",
+        "csharp": "0X123ABC"
+      },
+      {
+        "description": "Hex number lower",
+        "javascript": "0x123abc",
+        "python": "0x123abc",
+        "java": "0x123abc",
+        "csharp": "0x123abc"
+      },
+      {
+        "description": "Octal 0-prefix number",
+        "javascript": "01234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "1234567"
+      },
+      {
+        "description": "Octal 00-prefix number",
+        "javascript": "001234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "1234567"
+      },
+      {
+        "description": "Octal 0o-prefix number",
+        "javascript": "0o1234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "0"
+      },
+      {
+        "description": "Octal 0O-prefix number",
+        "javascript": "0o1234567",
+        "python": "0o1234567",
+        "java": "01234567",
+        "csharp": "0"
+      },
+      {
+        "description": "Single-quote string",
+        "javascript": "'string'",
+        "python": "'string'",
+        "java": "\"string\"",
+        "csharp": "\"string\""
+      },
+      {
+        "description": "Double-quote string",
+        "javascript": "\"string\"",
+        "python": "'string'",
+        "java": "\"string\"",
+        "csharp": "\"string\""
+      },
+      {
+        "description": "null",
+        "javascript": "null",
+        "python": "None",
+        "java": "null",
+        "csharp": "BsonNull.Value"
+      },
+      {
+        "description": "undefined",
+        "javascript": "undefined",
+        "python": "None",
+        "java": "null",
+        "csharp": "BsonUndefined.Value"
+      },
+      {
+        "description": "true",
+        "javascript": "true",
+        "python": "True",
+        "java": "true",
+        "csharp": "true"
+      },
+      {
+        "description": "false",
+        "javascript": "false",
+        "python": "False",
+        "java": "false",
+        "csharp": "false"
+      }
+    ],
+    "Date": [
+      {
+        "description": "new Date with ISO String",
+        "javascript": "new Date('December 17, 1995 03:24:00Z')",
+        "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819170640000)",
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
+      },
+      {
+        "description": "new Date with UTC number",
+        "javascript": "new Date(819167040000)",
+        "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819167040000)",
+        "csharp": "new DateTime(1995, 12, 17, 2, 24, 0)"
+      },
+      {
+        "description": "Current date",
+        "javascript": "new Date()",
+        "python": "datetime.datetime.utcnow().date()",
+        "java": "new java.util.Date()",
+        "csharp": "DateTime.Now"
+      },
+      {
+        "description": "Date from year, month and day",
+        "javascript": "new Date(1995, 11, 17)",
+        "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819158400000)",
+        "csharp": "new DateTime(1995, 12, 17, 0, 0, 0)"
+      },
+      {
+        "description": "Date from year, month, day, hour, min and sec",
+        "javascript": "new Date(1995, 11, 17, 3, 24, 0)",
+        "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
+        "java": "new java.util.Date(819170640000)",
+        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)"
+      }
+    ],
+    "RegExp": [
+      {
+        "description": "empty RegExp",
+        "javascript": "RegExp('')",
+        "python": "re.compile(r\"(?:)\")",
+        "java": "Pattern.compile(\"(?:)\")",
+        "csharp": ""
+      },
+      {
+        "description": "RegExp without options",
+        "javascript": "RegExp('abc')",
+        "python": "re.compile(r\"abc\")",
+        "java": "Pattern.compile(\"abc\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with im flags as args",
+        "javascript": "new RegExp('ab+c', 'im')",
+        "python": "re.compile(r\"ab+c(?im)\")",
+        "java": "Pattern.compile(\"ab+c(?im)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with ig flags as args",
+        "javascript": "new RegExp('ab+c', 'ig')",
+        "python": "re.compile(r\"ab+c(?is)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with forward slash",
+        "javascript": "new RegExp('ab/cd')",
+        "python": "re.compile(r\"ab\\/cd\")",
+        "java": "Pattern.compile(\"ab\\/cd\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with escaped double quote",
+        "javascript": "new RegExp('ab\\\"ab')",
+        "python": "re.compile(r\"ab\\\"ab\")",
+        "java": "Pattern.compile(\"ab\\\"ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with nonescaped double quote",
+        "javascript": "new RegExp('ab\"ab')",
+        "python": "re.compile(r\"ab\\\"ab\")",
+        "java": "Pattern.compile(\"ab\\\"ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with escaped single quote",
+        "javascript": "new RegExp('ab\\'ab')",
+        "python": "re.compile(r\"ab'ab\")",
+        "java": "Pattern.compile(\"ab'ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with nonescaped single quote",
+        "javascript": "new RegExp(\"ab'ab\")",
+        "python": "re.compile(r\"ab'ab\")",
+        "java": "Pattern.compile(\"ab'ab\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with newline",
+        "javascript": "new RegExp(\"\\\\n\")",
+        "python": "re.compile(r\"\\\\n\")",
+        "java": "Pattern.compile(\"\\\\n\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex literal with ig flags",
+        "javascript": "/ab+c/ig",
+        "python": "re.compile(r\"ab+c(?is)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      },
+      {
+        "description": "regex object with regex literal arg",
+        "javascript": "new RegExp(/ab+c/, 'i')",
+        "python": "re.compile(r\"ab+c(?i)\")",
+        "java": "Pattern.compile(\"ab+c(?i)\")",
+        "csharp": ""
+      }
+    ]
+  }
+}

--- a/test/json/success/shell/js-utils.json
+++ b/test/json/success/shell/js-utils.json
@@ -1,0 +1,13 @@
+{
+  "tests": {
+    "Date": [
+      {
+        "description": "Current time",
+        "javascript": "Date.now()",
+        "python": "datetime.datetime.utcnow()",
+        "java": "new java.util.Date()",
+        "csharp": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Previously our test suite expected all translations to be symmetric, but that's not always possible (especially as our generated code gets more idiomatic). 

For example, Code in javascript can accept a function or a string, but in shell it only accepts a string.

Javascript --> Shell:

```
Code(function(x){console.log(x)};) --> Code("function(x){console.log(x)};")
```
Shell --> Javascript 
```
Code("function(x){console.log(x)};") --> Code("function(x){console.log(x)};")
```

So now we have a folder for each output language, and in that folder the JSON files will only be tested from input language --> target language.