### PR TITLE
Misc bug fixes

### DIFF
--- a/codegeneration/java/Generator.js
+++ b/codegeneration/java/Generator.js
@@ -304,9 +304,11 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     return this.emitLong(ctx);
   }
 
+  /*
+   * This is a bit weird because we can just convert to string directly.
+   */
   emitLongtoString(ctx) {
     ctx.type = this.Types._string;
-    const lhsType = ctx.singleExpression().type;
     const long = ctx.singleExpression().singleExpression();
     let longstr;
     try {
@@ -314,11 +316,6 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     } catch (error) {
       throw new SemanticGenericError({message: error.message});
     }
-    const stringArgs = ctx.arguments().argumentList();
-    if (!stringArgs) {
-      return `java.lang.Long.toString(${longstr})`;
-    }
-    const arg = this.checkArguments(lhsType.args, stringArgs).join(', ');
-    return `java.lang.Long.toString(${longstr}, ${arg})`;
+    return `"${longstr}"`;
   }
 };

--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -391,12 +391,15 @@ class Visitor extends ECMAScriptVisitor {
           args[i].type === this.Types._integer ||
           args[i].type === this.Types._decimal ||
           args[i].type === this.Types._hex ||
-          args[i].type === this.Types._octal)) {
+          args[i].type === this.Types._octal ||
+          args[i].type === this.Types.Double ||
+          args[i].type === this.Types.Int32 ||
+          args[i].type === this.Types.Long)) {
         continue;
       }
       if (expected[i].indexOf(args[i].type) === -1 && expected[i].indexOf(args[i].type.id) === -1) {
         const message = `expected types ${expected[i].map((e) => {
-          return e.id ? e.id : e;
+          return e ? e.id ? e.id : e : '[optional]';
         })} but got type ${args[i].type.id} for argument at index ${i}`;
 
         throw new SemanticTypeError({message});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compile": "npm run antlr4-js && npm run symbol-table",
     "antlr4-js": "java -Xmx500M -cp '/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH' org.antlr.v4.Tool  -Dlanguage=JavaScript -lib grammars -o lib/antlr -visitor -Xexact-output-dir grammars/ECMAScript.g4",
     "symbol-table": "node compile-symbol-table.js",
-    "test": "mocha",
+    "test": "npm run symbol-table && mocha",
     "prepublish": "npm run compile",
     "check": "mongodb-js-precommit './codegeneration/**/*{.js,.jsx}' './test/**/*.js' index.js",
     "ci": "npm run check && npm run test"

--- a/test/json/success/javascript/bson-constructors.json
+++ b/test/json/success/javascript/bson-constructors.json
@@ -19,11 +19,11 @@
       },
       {
         "description": "Code with string code and object scope",
-        "javascript": "Code('string', {x: 1})",
-        "python": "Code('string', {'x': 1})",
-        "java": "new CodeWithScope(\"string\", new Document().append(\"x\", 1))",
-        "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", 1))",
-        "shell": "Code('string', {x: 1})"
+        "javascript": "Code('string', {x: '1'})",
+        "python": "Code('string', {'x': '1'})",
+        "java": "new CodeWithScope(\"string\", new Document().append(\"x\", \"1\"))",
+        "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", \"1\"))",
+        "shell": "Code('string', {x: '1'})"
       },
       {
         "description": "Code with function code",
@@ -35,11 +35,11 @@
       },
       {
         "description": "Code with where code",
-        "javascript": "new Code('this.a > i', { i: 1 })",
-        "python": "Code('this.a > i', {'i': 1})",
-        "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", 1))",
-        "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", 1))",
-        "shell": "Code('this.a > i', {i: 1})"
+        "javascript": "new Code('this.a > i', { i: '1' })",
+        "python": "Code('this.a > i', {'i': '1'})",
+        "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", \"1\"))",
+        "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", \"1\"))",
+        "shell": "Code('this.a > i', {i: '1'})"
       }
     ],
     "ObjectId": [
@@ -255,43 +255,43 @@
     ],
     "Document": [
       {
-        "description": "{x: 1}",
-        "javascript": "{x: 1}",
-        "python": "{'x': 1}",
-        "java": "new Document().append(\"x\", 1)",
-        "csharp": "new BsonDocument(\"x\", 1)",
+        "description": "{x: '1'}",
+        "javascript": "{x: '1'}",
+        "python": "{'x': '1'}",
+        "java": "new Document().append(\"x\", \"1\")",
+        "csharp": "new BsonDocument(\"x\", \"1\")",
         "shell": ""
       },
       {
         "description": "Doc with trailing comma",
-        "javascript": "{x: 1,}",
-        "python": "{'x': 1,}",
-        "java": "new Document().append(\"x\", 1)",
-        "csharp": "new BsonDocument(\"x\", 1)",
+        "javascript": "{x: '1',}",
+        "python": "{'x': '1',}",
+        "java": "new Document().append(\"x\", \"1\")",
+        "csharp": "new BsonDocument(\"x\", \"1\")",
         "shell": ""
       },
       {
         "description": "Doc with array",
-        "javascript": "{x: [1, 2]}",
-        "python": "{'x': [1, 2]}",
-        "java": "new Document().append(\"x\", Arrays.asList(1, 2))",
-        "csharp": "new BsonDocument(\"x\", new BsonArray {1, 2})",
+        "javascript": "{x: ['1', '2']}",
+        "python": "{'x': ['1', '2']}",
+        "java": "new Document().append(\"x\", Arrays.asList(\"1\", \"2\"))",
+        "csharp": "new BsonDocument(\"x\", new BsonArray {\"1\", \"2\"})",
         "shell": ""
       },
       {
         "description": "Doc with subdoc",
-        "javascript": "{x: {y: 2}}",
-        "python": "{'x': {'y': 2}}",
-        "java": "new Document().append(\"x\", new Document().append(\"y\", 2))",
-        "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", 2))",
+        "javascript": "{x: {y: '2'}}",
+        "python": "{'x': {'y': '2'}}",
+        "java": "new Document().append(\"x\", new Document().append(\"y\", \"2\"))",
+        "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", \"2\"))",
         "shell": ""
       },
       {
         "description": "Object.create()",
-        "javascript": "Object.create({x: 1})",
-        "python": "{'x': 1}",
-        "java": "new Document().append(\"x\", 1)",
-        "csharp": "new BsonDocument(\"x\", 1)",
+        "javascript": "Object.create({x: '1'})",
+        "python": "{'x': '1'}",
+        "java": "new Document().append(\"x\", \"1\")",
+        "csharp": "new BsonDocument(\"x\", \"1\")",
         "shell": ""
       },
       {
@@ -304,43 +304,43 @@
       },
       {
         "description": "Two items in document",
-        "javascript": "{x: 1, n: 4}",
-        "python": "{'x': 1, 'n': 4}",
-        "java": "new Document().append(\"x\", 1).append(\"n\", 4)",
-        "csharp": "new BsonDocument { { \"x\", 1 }, { \"n\", 4 } }"
+        "javascript": "{x: '1', n: '4'}",
+        "python": "{'x': '1', 'n': '4'}",
+        "java": "new Document().append(\"x\", \"1\").append(\"n\", \"4\")",
+        "csharp": "new BsonDocument { { \"x\", \"1\" }, { \"n\", \"4\" } }"
       }
     ],
     "Array": [
       {
-        "description": "[1, 2]",
-        "javascript": "[1, 2]",
-        "python": "[1, 2]",
-        "java": "Arrays.asList(1, 2)",
-        "csharp": "new BsonArray {1, 2}",
+        "description": "['1', '2']",
+        "javascript": "['1', '2']",
+        "python": "['1', '2']",
+        "java": "Arrays.asList(\"1\", \"2\")",
+        "csharp": "new BsonArray {\"1\", \"2\"}",
         "shell": ""
       },
       {
         "description": "array with trailing comma",
-        "javascript": "[1, 2,]",
-        "python": "[1, 2]",
-        "java": "Arrays.asList(1, 2)",
-        "csharp": "new BsonArray {1, 2}",
+        "javascript": "['1', '2',]",
+        "python": "['1', '2']",
+        "java": "Arrays.asList(\"1\", \"2\")",
+        "csharp": "new BsonArray {\"1\", \"2\"}",
         "shell": ""
       },
       {
         "description": "Array with subdoc",
-        "javascript": "[1, { settings: 'http2' }]",
-        "python": "[1, {'settings': 'http2'}]",
-        "java": "Arrays.asList(1, new Document().append(\"settings\", \"http2\"))",
-        "csharp": "new BsonArray {1, new BsonDocument(\"settings\", \"http2\")}",
+        "javascript": "['1', { settings: 'http2' }]",
+        "python": "['1', {'settings': 'http2'}]",
+        "java": "Arrays.asList(\"1\", new Document().append(\"settings\", \"http2\"))",
+        "csharp": "new BsonArray {\"1\", new BsonDocument(\"settings\", \"http2\")}",
         "shell": ""
       },
       {
         "description": "Array with subarray",
-        "javascript": "[1, [2, 3]]",
-        "python": "[1, [2, 3]]",
-        "java": "Arrays.asList(1, Arrays.asList(2, 3))",
-        "csharp": "new BsonArray {1, new BsonArray {2, 3}}",
+        "javascript": "['1', ['2', '3']]",
+        "python": "['1', ['2', '3']]",
+        "java": "Arrays.asList(\"1\", Arrays.asList(\"2\", \"3\"))",
+        "csharp": "new BsonArray {\"1\", new BsonArray {\"2\", \"3\"}}",
         "shell": ""
       },
       {
@@ -354,10 +354,10 @@
     "ArrayElision": [
       {
         "description": "array with leading elision",
-        "javascript": "[,1, 2,]",
-        "python": "[None, 1, 2]",
-        "java": "Arrays.asList(null, 1, 2)",
-        "csharp": "new BsonArray {BsonNull.Value, 1, 2}",
+        "javascript": "[,'1', '2',]",
+        "python": "[None, '1', '2']",
+        "java": "Arrays.asList(null, \"1\", \"2\")",
+        "csharp": "new BsonArray {BsonNull.Value, \"1\", \"2\"}",
         "shell": ""
       },
       {
@@ -378,10 +378,10 @@
       },
       {
         "description": "Array with elision in the middle",
-        "javascript": "[1,,,,2]",
-        "python": "[1, None, None, None, 2]",
-        "java": "Arrays.asList(1, null, null, null, 2)",
-        "csharp": "new BsonArray {1, BsonNull.Value, BsonNull.Value, BsonNull.Value, 2}"
+        "javascript": "['1',,,,'2']",
+        "python": "['1', None, None, None, '2']",
+        "java": "Arrays.asList(\"1\", null, null, null, \"2\")",
+        "csharp": "new BsonArray {\"1\", BsonNull.Value, BsonNull.Value, BsonNull.Value, \"2\"}"
       }
     ],
     "Symbol": [

--- a/test/json/success/javascript/bson-object-methods.json
+++ b/test/json/success/javascript/bson-object-methods.json
@@ -3,9 +3,9 @@
     "Code": [
       {
         "description": "CodeWithScope toJSON",
-        "javascript": "Code('test code', {x: 1}).toJSON()",
+        "javascript": "Code('test code', {x: '1'}).toJSON()",
         "python": "",
-        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", new Document().append(\"x\", 1))",
+        "java": "new Document().append(\"code\", \"test code\").append(\"scope\", new Document().append(\"x\", \"1\"))",
         "csharp": ""
       },
       {
@@ -164,14 +164,14 @@
         "description": "toString without radix",
         "javascript": "Long(1, 100).toString()",
         "python": "",
-        "java": "java.lang.Long.toString(429496729601)",
+        "java": "\"429496729601\"",
         "csharp": ""
       },
       {
         "description": "toString with radix",
         "javascript": "Long(1, 100).toString(10)",
         "python": "",
-        "java": "java.lang.Long.toString(429496729601, 10)",
+        "java": "\"429496729601\"",
         "csharp": ""
       },
       {


### PR DESCRIPTION
- Include BSON numeric types when type checking for "numeric" arguments.

- Indicate if an argument, that is of the wrong type, is also optional in the error message.

- In preparation for updating the numeric types to match the language defaults,  switch all the tests from using numbers to strings where possible. Doing this to save a lot of typing when `1` in javascript starts generating `java.lang.Long("1")`.

- Fix a bug where we were generating a int that is too large for java to handle.