### PR TITLE
Turn Max/MinKey into function call for shell

### DIFF
--- a/codegeneration/shell/Visitor.js
+++ b/codegeneration/shell/Visitor.js
@@ -27,10 +27,15 @@ class Visitor extends JavascriptVisitor {
       });
     }
     // Special case MinKey/MaxKey because they don't have to be called in shell
-    if ((ctx.type.id === 'MinKey' || ctx.type.id === 'MaxKey') &&
+    if (!ctx.visited && (ctx.type.id === 'MinKey' || ctx.type.id === 'MaxKey') &&
         ctx.parentCtx.constructor.name !== 'FuncCallExpressionContext' &&
         ctx.parentCtx.constructor.name !== 'NewExpressionContext') {
-      return `new ${ctx.type.id}()`;
+      const node = {
+        arguments: () => { return { argumentList: () => { return false; }}; },
+        singleExpression: () => { return ctx; }
+      };
+      ctx.visited = true;
+      return this.visitFuncCallExpression(node);
     }
     if (ctx.type.template) {
       return ctx.type.template();


### PR DESCRIPTION
Because `minKey`, `new MinKey`, `MinKey()` and `new MinKey()` are all valid and equivalent, we need to special case the `visitIdentifierExpression` in the shell visitor. What this is doing is basically rearranging the tree so the identifier on it's own becomes a function call. 

If the visitor encounters a `MinKey` identifier that is not part of a `newExpression` or a `FuncCallExpression`, then it will create a fake "FunctionCallExpressionContext" (`node`) and calls `visitFuncCallExpressionExpression` on it directly so from the generators perspective, it's exactly the same as if the original code was `MinKey()`. 

Also true for MaxKey.