### PR TITLE
Remove support for new X

### DIFF
--- a/codegeneration/javascript/Visitor.js
+++ b/codegeneration/javascript/Visitor.js
@@ -247,13 +247,6 @@ class Visitor extends ECMAScriptVisitor {
    * @return {String}
    */
   visitNewExpression(ctx) {
-    ctx.singleExpression().wasNew = true;
-    if (!('arguments' in ctx.singleExpression())) {
-      ctx.arguments = () => { return { argumentList: () => { return false; }}; };
-      ctx.type = ctx.singleExpression().type;
-      ctx.getText = () => { return `${ctx.singleExpression().getText()}`; };
-      return this.visitFuncCallExpression(ctx);
-    }
     if ('emitNew' in this) {
       return this.emitNew(ctx);
     }

--- a/test/json/success/javascript/bson-constructors.json
+++ b/test/json/success/javascript/bson-constructors.json
@@ -229,22 +229,6 @@
         "java": "new MaxKey()",
         "csharp": "BsonMaxKey.Value",
         "shell": "new MaxKey()"
-      },
-      {
-        "description": "new MaxKey",
-        "javascript": "new MaxKey",
-        "python": "MaxKey()",
-        "java": "new MaxKey()",
-        "csharp": "BsonMaxKey.Value",
-        "shell": "new MaxKey()"
-      },
-      {
-        "description": "new MinKey",
-        "javascript": "new MinKey",
-        "python": "MinKey()",
-        "java": "new MinKey()",
-        "csharp": "BsonMinKey.Value",
-        "shell": "new MinKey()"
       }
     ],
     "BSONRegExp": [


### PR DESCRIPTION
Remove support for weird syntax like `new MaxKey` or `new ObjectId` because nobody seems to have heard of it and it's a headache to maintain. Merging bc we talked about it at standup.