### PR TITLE
[WIP] verify c# tests

### DIFF
--- a/test/json/success/javascript/bson-constructors.json
+++ b/test/json/success/javascript/bson-constructors.json
@@ -6,7 +6,7 @@
         "javascript": "new Code('some code')",
         "python": "Code('some code')",
         "java": "new Code(\"some code\")",
-        "csharp": "new BsonJavaScript(@\"some code\")",
+        "csharp": "",
         "shell": "Code('some code')"
       },
       {
@@ -14,7 +14,7 @@
         "javascript": "Code('some code')",
         "python": "Code('some code')",
         "java": "new Code(\"some code\")",
-        "csharp": "new BsonJavaScript(@\"some code\")",
+        "csharp": "",
         "shell": "Code('some code')"
       },
       {
@@ -22,7 +22,7 @@
         "javascript": "Code('string', {x: '1'})",
         "python": "Code('string', {'x': '1'})",
         "java": "new CodeWithScope(\"string\", new Document().append(\"x\", \"1\"))",
-        "csharp": "new BsonJavaScriptWithScope(@\"string\", new BsonDocument(\"x\", \"1\"))",
+        "csharp": "",
         "shell": "Code('string', {x: '1'})"
       },
       {
@@ -30,7 +30,7 @@
         "javascript": "Code(function(test) { console.log(test); })",
         "python": "Code('function(test){console.log(test);}')",
         "java": "new Code(\"function(test){console.log(test);}\")",
-        "csharp": "new BsonJavaScript(@\"function(test){console.log(test);}\")",
+        "csharp": "",
         "shell": "Code('function(test){console.log(test);}')"
       },
       {
@@ -38,7 +38,7 @@
         "javascript": "new Code('this.a > i', { i: '1' })",
         "python": "Code('this.a > i', {'i': '1'})",
         "java": "new CodeWithScope(\"this.a > i\", new Document().append(\"i\", \"1\"))",
-        "csharp": "new BsonJavaScriptWithScope(@\"this.a > i\", new BsonDocument(\"i\", \"1\"))",
+        "csharp": "",
         "shell": "Code('this.a > i', {i: '1'})"
       }
     ],
@@ -48,7 +48,7 @@
         "javascript": "ObjectId()",
         "python": "ObjectId()",
         "java": "new ObjectId()",
-        "csharp": "new ObjectId()",
+        "csharp": "",
         "shell": "ObjectId()"
       },
       {
@@ -56,7 +56,7 @@
         "javascript": "new ObjectId()",
         "python": "ObjectId()",
         "java": "new ObjectId()",
-        "csharp": "new ObjectId()",
+        "csharp": "",
         "shell": "new ObjectId()"
       },
       {
@@ -64,7 +64,7 @@
         "javascript": "ObjectId('5a7382114ec1f67ae445f778')",
         "python": "ObjectId('5a7382114ec1f67ae445f778')",
         "java": "new ObjectId(\"5a7382114ec1f67ae445f778\")",
-        "csharp": "new ObjectId(\"5a7382114ec1f67ae445f778\")",
+        "csharp": "",
         "shell": "new ObjectId('5a7382114ec1f67ae445f778')"
       }
     ],
@@ -74,7 +74,7 @@
         "javascript": "Binary(Buffer.from('1234'))",
         "python": "Binary(b'1234')",
         "java": "new Binary(\"1234\".getBytes(\"UTF-8\"))",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"))",
+        "csharp": "",
         "shell": "new BinData(4, '1234')"
       },
       {
@@ -82,7 +82,7 @@
         "javascript": "new Binary(Buffer.from(\"1234\"), Binary.SUBTYPE_UUID)",
         "python": "Binary(b'1234', bson.binary.UUID_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.UUID_STANDARD, \"1234\".getBytes(\"UTF-8\"))",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"), BsonBinarySubType.UuidStandard)",
+        "csharp": "",
         "shell": "new BinData(4, '1234')"
       },
       {
@@ -90,7 +90,7 @@
         "javascript": "Binary(Buffer.from('1234'), '1')",
         "python": "Binary(b'1234', bson.binary.FUNCTION_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"1234\".getBytes(\"UTF-8\"))",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"), BsonBinarySubType.Function)",
+        "csharp": "",
         "shell": "new BinData(1, '1234')"
       },
       {
@@ -98,7 +98,7 @@
         "javascript": "Binary('1234')",
         "python": "Binary(b'1234')",
         "java": "new Binary(\"1234\".getBytes(\"UTF-8\"))",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"))",
+        "csharp": "",
         "shell": "new BinData(1, '1234')"
       },
       {
@@ -106,7 +106,7 @@
         "javascript": "Binary('1234', '1')",
         "python": "Binary(b'1234', bson.binary.FUNCTION_SUBTYPE)",
         "java": "new Binary(org.bson.BsonBinarySubType.FUNCTION, \"1234\".getBytes(\"UTF-8\"))",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"1234\"), BsonBinarySubType.Function)",
+        "csharp": "",
         "shell": "new BinData(4, '1234')"
       }
     ],
@@ -116,7 +116,7 @@
         "javascript": "new DBRef('coll', new ObjectId())",
         "python": "DBRef('coll', ObjectId())",
         "java": "new DBRef(\"coll\", new ObjectId())",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId())",
+        "csharp": "",
         "shell": "new DBRef('coll', new ObjectId())"
       },
       {
@@ -124,7 +124,7 @@
         "javascript": "new DBRef('coll', ObjectId(), 'db')",
         "python": "DBRef('coll', ObjectId(), 'db')",
         "java": "new DBRef(\"db\", \"coll\", new ObjectId())",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId(), \"db\")",
+        "csharp": "",
         "shell": "new DBRef('coll', ObjectId(), 'db')"
       }
     ],
@@ -134,7 +134,7 @@
         "javascript": "Int32(3)",
         "python": "int(3)",
         "java": "new java.lang.Integer(3)",
-        "csharp": "Convert.ToInt32(3)",
+        "csharp": "",
         "shell": "NumberInt(3)"
       },
       {
@@ -142,7 +142,7 @@
         "javascript": "Int32('3')",
         "python": "int('3')",
         "java": "new java.lang.Integer(\"3\")",
-        "csharp": "Int32.Parse(\"3\")",
+        "csharp": "",
         "shell": "NumberInt('3')"
       }
     ],
@@ -152,7 +152,7 @@
         "javascript": "Double(3)",
         "python": "float(3)",
         "java": "new java.lang.Double(3)",
-        "csharp": "new BsonDouble(3)",
+        "csharp": "",
         "shell": "3"
       },
       {
@@ -160,7 +160,7 @@
         "javascript": "new Double(3)",
         "python": "float(3)",
         "java": "new java.lang.Double(3)",
-        "csharp": "new BsonDouble(3)",
+        "csharp": "",
         "shell": "3"
       },
       {
@@ -168,7 +168,7 @@
         "javascript": "Double('3')",
         "python": "float('3')",
         "java": "new java.lang.Double(\"3\")",
-        "csharp": "new BsonDouble(3)",
+        "csharp": "",
         "shell": "3"
       }
     ],
@@ -178,7 +178,7 @@
         "javascript": "new Long(-1, 2147483647)",
         "python": "Int64(9223372036854775807)",
         "java": "new java.lang.Long(\"9223372036854775807\")",
-        "csharp": "new BsonInt64(9223372036854775807)",
+        "csharp": "",
         "shell": "new Long(9223372036854775807)"
       }
     ],
@@ -188,7 +188,7 @@
         "javascript": "new Decimal128(Buffer.from('5'))",
         "python": "Decimal128('5.3E-6175')",
         "java": "Decimal128.parse(\"5.3E-6175\")",
-        "csharp": "new Decimal128(5)",
+        "csharp": "",
         "shell": "new NumberDecimal(5.3E-6175)"
       }
     ],
@@ -198,7 +198,7 @@
         "javascript": "MinKey()",
         "python": "MinKey()",
         "java": "new MinKey()",
-        "csharp": "BsonMinKey.Value",
+        "csharp": "",
         "shell": "MinKey()"
       },
       {
@@ -206,7 +206,7 @@
         "javascript": "MaxKey()",
         "python": "MaxKey()",
         "java": "new MaxKey()",
-        "csharp": "BsonMaxKey.Value",
+        "csharp": "",
         "shell": "MaxKey()"
       },
       {
@@ -214,7 +214,7 @@
         "javascript": "new MaxKey()",
         "python": "MaxKey()",
         "java": "new MaxKey()",
-        "csharp": "BsonMaxKey.Value",
+        "csharp": "",
         "shell": "new MaxKey()"
       },
       {
@@ -222,7 +222,7 @@
         "javascript": "new MinKey()",
         "python": "MinKey()",
         "java": "new MinKey()",
-        "csharp": "BsonMinKey.Value",
+        "csharp": "",
         "shell": "new MinKey()"
       }
     ],
@@ -232,7 +232,7 @@
         "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$')",
         "python": "Regex('^[a-z0-9_-]{3,16}$')",
         "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\")",
-        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\")",
+        "csharp": "",
         "shell": "new BSONRegExp('^[a-z0-9_-]{3,16}$')"
       },
       {
@@ -240,7 +240,7 @@
         "javascript": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')",
         "python": "Regex('^[a-z0-9_-]{3,16}$', 'imuxls')",
         "java": "new BsonRegularExpression(\"^[a-z0-9_-]{3,16}$\", \"imuxls\")",
-        "csharp": "new BsonRegularExpression(@\"^[a-z0-9_-]{3,16}$\", \"imxs\")",
+        "csharp": "",
         "shell": "new BSONRegExp('^[a-z0-9_-]{3,16}$', 'imuxls')"
       }
     ],
@@ -250,7 +250,7 @@
         "javascript": "Timestamp(10, 100)",
         "python": "Timestamp(10, 100)",
         "java": "new BSONTimestamp(10, 100)",
-        "csharp": "new BsonTimestamp(10, 100)",
+        "csharp": "",
         "shell": "Timestamp(10, 100)"
       },
       {
@@ -258,7 +258,7 @@
         "javascript": "new Timestamp(10, 100)",
         "python": "Timestamp(10, 100)",
         "java": "new BSONTimestamp(10, 100)",
-        "csharp": "new BsonTimestamp(10, 100)",
+        "csharp": "",
         "shell": "new Timestamp(10, 100)"
       }
     ],
@@ -268,7 +268,7 @@
         "javascript": "{x: '1'}",
         "python": "{'x': '1'}",
         "java": "new Document().append(\"x\", \"1\")",
-        "csharp": "new BsonDocument(\"x\", \"1\")",
+        "csharp": "",
         "shell": "{x: '1'}"
       },
       {
@@ -276,7 +276,7 @@
         "javascript": "{x: '1',}",
         "python": "{'x': '1'}",
         "java": "new Document().append(\"x\", \"1\")",
-        "csharp": "new BsonDocument(\"x\", \"1\")",
+        "csharp": "",
         "shell": "{x: '1',}"
       },
       {
@@ -284,7 +284,7 @@
         "javascript": "{x: ['1', '2']}",
         "python": "{'x': ['1', '2']}",
         "java": "new Document().append(\"x\", Arrays.asList(\"1\", \"2\"))",
-        "csharp": "new BsonDocument(\"x\", new BsonArray {\"1\", \"2\"})",
+        "csharp": "",
         "shell": "{x: ['1', '2']}"
       },
       {
@@ -292,7 +292,7 @@
         "javascript": "{x: {y: '2'}}",
         "python": "{'x': {'y': '2'}}",
         "java": "new Document().append(\"x\", new Document().append(\"y\", \"2\"))",
-        "csharp": "new BsonDocument(\"x\", new BsonDocument(\"y\", \"2\"))",
+        "csharp": "",
         "shell": "{x: {y: '2'}}"
       },
       {
@@ -300,7 +300,7 @@
         "javascript": "Object.create({x: '1'})",
         "python": "{'x': '1'}",
         "java": "new Document().append(\"x\", \"1\")",
-        "csharp": "new BsonDocument(\"x\", \"1\")",
+        "csharp": "",
         "shell": "Object.create({x: '1'})"
       },
       {
@@ -308,7 +308,7 @@
         "javascript": "{}",
         "python": "{}",
         "java": "new Document()",
-        "csharp": "new BsonDocument()",
+        "csharp": "",
         "shell": "{}"
       },
       {
@@ -316,7 +316,7 @@
         "javascript": "{x: '1', n: '4'}",
         "python": "{'x': '1', 'n': '4'}",
         "java": "new Document().append(\"x\", \"1\").append(\"n\", \"4\")",
-        "csharp": "new BsonDocument{ { \"x\", \"1\" }, { \"n\", \"4\" } }",
+        "csharp": "",
         "shell": "{x: '1', n: '4'}"
       }
     ],
@@ -326,7 +326,7 @@
         "javascript": "['1', '2']",
         "python": "['1', '2']",
         "java": "Arrays.asList(\"1\", \"2\")",
-        "csharp": "new BsonArray {\"1\", \"2\"}",
+        "csharp": "",
         "shell": "['1', '2']"
       },
       {
@@ -334,7 +334,7 @@
         "javascript": "['1', '2',]",
         "python": "['1', '2']",
         "java": "Arrays.asList(\"1\", \"2\")",
-        "csharp": "new BsonArray {\"1\", \"2\"}",
+        "csharp": "",
         "shell": "['1', '2',]"
       },
       {
@@ -342,7 +342,7 @@
         "javascript": "['1', { settings: 'http2' }]",
         "python": "['1', {'settings': 'http2'}]",
         "java": "Arrays.asList(\"1\", new Document().append(\"settings\", \"http2\"))",
-        "csharp": "new BsonArray {\"1\", new BsonDocument(\"settings\", \"http2\")}",
+        "csharp": "",
         "shell": "['1', { settings: 'http2' }]"
       },
       {
@@ -350,7 +350,7 @@
         "javascript": "['1', ['2', '3']]",
         "python": "['1', ['2', '3']]",
         "java": "Arrays.asList(\"1\", Arrays.asList(\"2\", \"3\"))",
-        "csharp": "new BsonArray {\"1\", new BsonArray {\"2\", \"3\"}}",
+        "csharp": "",
         "shell": "['1', ['2', '3']]"
       },
       {
@@ -358,7 +358,7 @@
         "javascript": "[]",
         "python": "[]",
         "java": "Arrays.asList()",
-        "csharp": "new BsonArray()",
+        "csharp": "",
         "shell": "[]"
       }
     ],
@@ -368,7 +368,7 @@
         "javascript": "[,'1', '2',]",
         "python": "[None, '1', '2']",
         "java": "Arrays.asList(null, \"1\", \"2\")",
-        "csharp": "new BsonArray {BsonUndefined.Value, \"1\", \"2\"}",
+        "csharp": "",
         "shell": "[,'1', '2',]"
       },
       {
@@ -376,7 +376,7 @@
         "javascript": "[,]",
         "python": "[None]",
         "java": "Arrays.asList(null)",
-        "csharp": "new BsonArray {BsonUndefined.Value}",
+        "csharp": "",
         "shell": "[,]"
       },
       {
@@ -384,7 +384,7 @@
         "javascript": "[,,]",
         "python": "[None, None]",
         "java": "Arrays.asList(null, null)",
-        "csharp": "new BsonArray {BsonUndefined.Value, BsonUndefined.Value}",
+        "csharp": "",
         "shell": "[,,]"
       },
       {
@@ -392,7 +392,7 @@
         "javascript": "['1',,,,'2']",
         "python": "['1', None, None, None, '2']",
         "java": "Arrays.asList(\"1\", null, null, null, \"2\")",
-        "csharp": "new BsonArray {\"1\", BsonUndefined.Value, BsonUndefined.Value, BsonUndefined.Value, \"2\"}",
+        "csharp": "",
         "shell": "['1',,,,'2']"
       }
     ],
@@ -402,7 +402,7 @@
         "javascript": "Symbol('2')",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\")",
-        "csharp": "new BsonString(\"2\")",
+        "csharp": "",
         "shell": "'2'"
       },
       {
@@ -410,7 +410,7 @@
         "javascript": "new Symbol('2')",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\")",
-        "csharp": "new BsonString(\"2\")",
+        "csharp": "",
         "shell": "'2'"
       }
     ]

--- a/test/json/success/javascript/bson-methods.json
+++ b/test/json/success/javascript/bson-methods.json
@@ -6,7 +6,7 @@
         "javascript": "Code('test code', {x: 1}).scope",
         "python": "Code('test code', {'x': 1}).scope",
         "java": "new CodeWithScope(\"test code\", new Document().append(\"x\", new java.lang.Long(\"1\"))).getScope()",
-        "csharp": "new BsonJavaScriptWithScope(@\"test code\", new BsonDocument(\"x\", 1)).Scope",
+        "csharp": "",
         "shell": "Code('test code', {x: 1}).scope"
       },
       {
@@ -14,7 +14,7 @@
         "javascript": "Code('test code').code",
         "python": "str(Code('test code'))",
         "java": "new Code(\"test code\").getCode()",
-        "csharp": "new BsonJavaScript(@\"test code\").Code",
+        "csharp": "",
         "shell": "Code('test code').code"
       },
       {
@@ -22,7 +22,7 @@
         "javascript": "Code('test code').toString()",
         "python": "repr(Code('test code'))",
         "java": "new Code(\"test code\").toString()",
-        "csharp": "new BsonJavaScript(@\"test code\").ToString()",
+        "csharp": "",
         "shell": "Code('test code').toString()"
       }
     ],
@@ -32,7 +32,7 @@
         "javascript": "ObjectId().toString()",
         "python": "str(ObjectId())",
         "java": "new ObjectId().toString()",
-        "csharp": "new ObjectId().ToString()",
+        "csharp": "",
         "shell": "Code('test code').toString()"
 
       },
@@ -41,7 +41,7 @@
         "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').toString()",
         "python": "str(ObjectId('5ab901c29ee65f5c8550c5b9'))",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").toString()",
-        "csharp": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").ToString()",
+        "csharp": "",
         "shell": "ObjectId().toString()"
       },
       {
@@ -49,7 +49,7 @@
         "javascript": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()",
         "python": "ObjectId('5ab901c29ee65f5c8550c5b9').generation_time",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").getTimestamp()",
-        "csharp": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\").Timestamp",
+        "csharp": "",
         "shell": "ObjectId('5ab901c29ee65f5c8550c5b9').getTimestamp()"
       },
       {
@@ -57,7 +57,7 @@
         "javascript": "ObjectId().equals(ObjectId())",
         "python": "ObjectId() == ObjectId()",
         "java": "new ObjectId().equals(new ObjectId())",
-        "csharp": "new ObjectId().Equals(new ObjectId())",
+        "csharp": "",
         "shell": "ObjectId().equals(ObjectId())"
       }
     ],
@@ -67,7 +67,7 @@
         "javascript": "Binary(Buffer.from('a string')).length()",
         "python": "len(bytearray(Binary(b'a string')))",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).length()",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\")).Length",
+        "csharp": "",
         "shell": "BinData(1, '0001').length()"
       },
       {
@@ -75,7 +75,7 @@
         "javascript": "Binary(Buffer.from('0001')).sub_type",
         "python": "Binary(b'0001').subtype",
         "java": "new Binary(\"0001\".getBytes(\"UTF-8\")).getType()",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"0001\")).SubType",
+        "csharp": "",
         "shell": "BinData(0, '0001').subtype()"
       },
       {
@@ -83,7 +83,7 @@
         "javascript": "Binary(Buffer.from('a string')).value()",
         "python": "str(Binary(b'a string'))",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).getData()",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\")).ToString()",
+        "csharp": "",
         "shell": "BinData(1, '0001').hex()"
       },
       {
@@ -91,7 +91,7 @@
         "javascript": "Binary(Buffer.from('a string')).toString()",
         "python": "str(Binary(b'a string'))",
         "java": "new Binary(\"a string\".getBytes(\"UTF-8\")).toString()",
-        "csharp": "new BsonBinaryData(System.Text.Encoding.ASCII.GetBytes(\"a string\")).ToString()",
+        "csharp": "",
         "shell": "BinData(1, '0001').toString()"
       }
     ],
@@ -101,7 +101,7 @@
         "javascript": "new DBRef('coll', new ObjectId()).toString()",
         "python": "str(DBRef('coll', ObjectId()))",
         "java": "new DBRef(\"coll\", new ObjectId()).toString()",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId()).ToString()",
+        "csharp": "",
         "shell": "new DBRef('coll', new ObjectId()).toString()"
       },
       {
@@ -109,7 +109,7 @@
         "javascript": "new DBRef('coll', new ObjectId()).db",
         "python": "DBRef('coll', ObjectId()).database",
         "java": "new DBRef(\"coll\", new ObjectId()).getDatabaseName()",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId()).DatabaseName",
+        "csharp": "",
         "shell": "new DBRef('coll', new ObjectId()).getDb()"
       },
       {
@@ -117,7 +117,7 @@
         "javascript": "new DBRef('coll', new ObjectId()).namespace",
         "python": "DBRef('coll', ObjectId()).collection",
         "java": "new DBRef(\"coll\", new ObjectId()).getCollectionName()",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId()).CollectionName",
+        "csharp": "",
         "shell": "new DBRef('coll', new ObjectId()).getCollection()"
       },
       {
@@ -125,7 +125,7 @@
         "javascript": "new DBRef('coll', new ObjectId()).oid",
         "python": "DBRef('coll', ObjectId()).id",
         "java": "new DBRef(\"coll\", new ObjectId()).getId()",
-        "csharp": "new MongoDBRef(\"coll\", new ObjectId()).Id",
+        "csharp": "",
         "shell": "new DBRef('coll', new ObjectId()).getId()"
       }
     ],
@@ -135,7 +135,7 @@
         "javascript": "Int32(3).valueOf()",
         "python": "int(3)",
         "java": "new java.lang.Integer(3).intValue()",
-        "csharp": "Convert.ToInt32(3)"
+        "csharp": ""
       }
     ],
     "Double": [
@@ -144,7 +144,7 @@
         "javascript": "Double(3).valueOf()",
         "python": "float(3)",
         "java": "new java.lang.Double(3).doubleValue()",
-        "csharp": "new BsonDouble(3).Value",
+        "csharp": "",
         "shell": "NumberInt(3).valueOf()"
       }
     ],
@@ -154,7 +154,7 @@
         "javascript": "Long(1, 100).toInt()",
         "python": "int(Int64(429496729601))",
         "java": "new java.lang.Long(\"429496729601\").intValue()",
-        "csharp": "new BsonInt64(429496729601).ToInt32()",
+        "csharp": "",
         "shell": "NumberLong(429496729601).valueOf()"
       },
       {
@@ -162,7 +162,7 @@
         "javascript": "Long(1, 100).toNumber()",
         "python": "float(Int64(429496729601))",
         "java": "new java.lang.Long(\"429496729601\").floatValue()",
-        "csharp": "new BsonInt64(429496729601).Value",
+        "csharp": "",
         "shell": "NumberLong(429496729601).floatApprox"
       },
       {
@@ -170,7 +170,7 @@
         "javascript": "Long(1, 100).toString()",
         "python": "'429496729601'",
         "java": "\"429496729601\"",
-        "csharp": "\"429496729601\"",
+        "csharp": "",
         "shell": ""
       },
       {
@@ -178,7 +178,7 @@
         "javascript": "Long(1, 100).toString(10)",
         "python": "'429496729601'",
         "java": "\"429496729601\"",
-        "csharp": "\"429496729601\"",
+        "csharp": "",
         "shell": ""
       },
       {
@@ -186,7 +186,7 @@
         "javascript": "Long(1, 100).isZero()",
         "python": "Int64(429496729601) == 0",
         "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(0))",
-        "csharp": "new BsonInt64(429496729601) == 0",
+        "csharp": "",
         "shell": "NumberLong(429496729601) === 0"
       },
       {
@@ -194,7 +194,7 @@
         "javascript": "Long(1, 100).isNegative()",
         "python": "Int64(429496729601) < 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(0)) < 0",
-        "csharp": "new BsonInt64(429496729601) < 0",
+        "csharp": "",
         "shell": "NumberLong(429496729601) < 0"
       },
       {
@@ -202,7 +202,7 @@
         "javascript": "Long(1, 100).isOdd()",
         "python": "(Int64(429496729601) % 2) == 0",
         "java": "new java.lang.Long(\"429496729601\") % 2 == 0",
-        "csharp": "new BsonInt64(429496729601).ToInt64() % 2 == 0",
+        "csharp": "",
         "shell": "(NumberLong(429496729601) % 2) === 0"
       },
       {
@@ -210,7 +210,7 @@
         "javascript": "Long(1, 100).equals(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) == 0",
         "java": "new java.lang.Long(\"429496729601\").equals(new java.lang.Long(\"4294967305\"))",
-        "csharp": "new BsonInt64(429496729601).ToInt64() == new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) === NumberLong(4294967305)"
       },
       {
@@ -218,7 +218,7 @@
         "javascript": "Long(1, 100).notEquals(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) != 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) != 0",
-        "csharp": "new BsonInt64(429496729601).ToInt64() != new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) !== NumberLong(4294967305)"
       },
       {
@@ -226,7 +226,7 @@
         "javascript": "Long(1, 100).compare(Long(9, 1))",
         "python": "Int64(429496729601) - Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\"))",
-        "csharp": "new BsonInt64(429496729601).CompareTo(new BsonInt64(4294967305))",
+        "csharp": "",
         "shell": "NumberLong(429496729601) - NumberLong(4294967305)"
       },
       {
@@ -234,7 +234,7 @@
         "javascript": "Long(1, 100).greaterThan(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) > 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) > 0",
-        "csharp": "new BsonInt64(429496729601) > new BsonInt64(4294967305)",
+        "csharp": "",
         "shell": "NumberLong(429496729601) > NumberLong(4294967305)"
       },
       {
@@ -242,7 +242,7 @@
         "javascript": "Long(1, 100).greaterThanOrEqual(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) >= 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) >= 0",
-        "csharp": "new BsonInt64(429496729601) >= new BsonInt64(4294967305)",
+        "csharp": "",
         "shell": "NumberLong(429496729601) >= NumberLong(4294967305)"
       },
       {
@@ -250,7 +250,7 @@
         "javascript": "Long(1, 100).lessThan(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) < 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) < 0",
-        "csharp": "new BsonInt64(429496729601) < new BsonInt64(4294967305)",
+        "csharp": "",
         "shell": "NumberLong(429496729601) < NumberLong(4294967305)"
       },
       {
@@ -258,7 +258,7 @@
         "javascript": "Long(1, 100).lessThanOrEqual(Long(9, 1))",
         "python": "(Int64(429496729601) - Int64(4294967305)) <= 0",
         "java": "new java.lang.Long(\"429496729601\").compareTo(new java.lang.Long(\"4294967305\")) <= 0",
-        "csharp": "new BsonInt64(429496729601) <= new BsonInt64(4294967305)",
+        "csharp": "",
         "shell": "NumberLong(429496729601) <= NumberLong(4294967305)"
       },
       {
@@ -266,7 +266,7 @@
         "javascript": "Long(1, 100).negate())",
         "python": "-Int64(429496729601)",
         "java": "-new java.lang.Long(\"429496729601\")",
-        "csharp": "-new BsonInt64(429496729601).ToInt64()",
+        "csharp": "",
         "shell": "-NumberLong(429496729601)"
       },
       {
@@ -274,7 +274,7 @@
         "javascript": "Long(1, 100).add(Long(9, 1))",
         "python": "Int64(429496729601) + Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") + new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() + new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) + NumberLong(4294967305)"
       },
       {
@@ -282,7 +282,7 @@
         "javascript": "Long(1, 100).subtract(Long(9, 1))",
         "python": "Int64(429496729601) - Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") - new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() - new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) - NumberLong(4294967305)"
       },
       {
@@ -290,7 +290,7 @@
         "javascript": "Long(1, 100).multiply(Long(9, 1))",
         "python": "Int64(429496729601) * Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") * new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() * new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) * NumberLong(4294967305)"
       },
       {
@@ -298,7 +298,7 @@
         "javascript": "Long(1, 100).div(Long(9, 1))",
         "python": "Int64(429496729601) / Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") / new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() / new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) / NumberLong(4294967305)"
       },
       {
@@ -306,7 +306,7 @@
         "javascript": "Long(1, 100).modulo(Long(9, 1))",
         "python": "Int64(429496729601) % Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") % new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() % new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) % NumberLong(4294967305)"
       },
       {
@@ -314,7 +314,7 @@
         "javascript": "Long(1, 100).not()",
         "python": "~Int64(429496729601)",
         "java": "~new java.lang.Long(\"429496729601\")",
-        "csharp": "!new BsonInt64(429496729601).ToInt64()",
+        "csharp": "",
         "shell": "~NumberLong(429496729601)"
       },
       {
@@ -322,7 +322,7 @@
         "javascript": "Long(1, 100).and(Long(9, 1))",
         "python": "Int64(429496729601) & Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") & new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() & new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) & NumberLong(4294967305)"
       },
       {
@@ -330,15 +330,13 @@
         "javascript": "Long(1, 100).or(Long(9, 1))",
         "python": "Int64(429496729601) | Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") | new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() | new BsonInt64(4294967305).ToInt64()",
-        "shell": "NumberLong(429496729601) <= NumberLong(4294967305)"
-      },
+        "csharp": "",
       {
         "description": "xor",
         "javascript": "Long(1, 100).xor(Long(9, 1))",
         "python": "Int64(429496729601) ^ Int64(4294967305)",
         "java": "new java.lang.Long(\"429496729601\") ^ new java.lang.Long(\"4294967305\")",
-        "csharp": "new BsonInt64(429496729601).ToInt64() ^ new BsonInt64(4294967305).ToInt64()",
+        "csharp": "",
         "shell": "NumberLong(429496729601) ^ NumberLong(4294967305)"
       },
       {
@@ -346,7 +344,7 @@
         "javascript": "Long(1, 100).shiftLeft(10)",
         "python": "Int64(429496729601) << 10",
         "java": "java.lang.Long.rotateLeft(new java.lang.Long(\"429496729601\"), 10)",
-        "csharp": "new BsonInt64(429496729601).ToInt32() << 10",
+        "csharp": "",
         "shell": "NumberLong(429496729601) << 10"
       },
       {
@@ -354,7 +352,7 @@
         "javascript": "Long(1, 100).shiftRight(10)",
         "python": "Int64(429496729601) >> 10",
         "java": "java.lang.Long.rotateRight(new java.lang.Long(\"429496729601\"), 10)",
-        "csharp": "new BsonInt64(429496729601).ToInt32() >> 10",
+        "csharp": "",
         "shell": "NumberLong(429496729601) >> 10"
       }
     ],
@@ -364,7 +362,7 @@
         "javascript": "new Decimal128(Buffer.from('5')).toString()",
         "python": "str(Decimal128('5.3E-6175'))",
         "java": "Decimal128.parse(\"5.3E-6175\").toString()",
-        "csharp": "new Decimal128(5).ToString()",
+        "csharp": "",
         "shell": "NumberDecimal(0).toString()"
       }
     ],
@@ -374,7 +372,7 @@
         "javascript": "Timestamp(1, 100).toString()",
         "python": "str(Timestamp(1, 100))",
         "java": "new BSONTimestamp(1, 100).toString()",
-        "csharp": "new BsonTimestamp(1, 100).ToString()",
+        "csharp": "",
         "shell": "Timestamp(1, 100).toString()"
       },
       {
@@ -382,7 +380,7 @@
         "javascript": "Timestamp(1, 100).equals(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) == 0",
         "java": "new BSONTimestamp(1, 100).equals(new BSONTimestamp(2, 99))",
-        "csharp": "new BsonTimestamp(1, 100).Equals(new BsonTimestamp(2, 99))",
+        "csharp": "",
         "shell": "Timestamp(1, 100) === Timestamp(2, 99)"
       },
       {
@@ -390,7 +388,7 @@
         "javascript": "Timestamp(1, 100).compare(Timestamp(2, 99))",
         "python": "Timestamp(1, 100).time - Timestamp(2, 99).time",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99))",
-        "csharp": "new BsonTimestamp(1, 100).CompareTo(new BsonTimestamp(2, 99))",
+        "csharp": "",
         "shell": "Timestamp(1, 100) - Timestamp(2, 99)"
       },
       {
@@ -398,7 +396,7 @@
         "javascript": "Timestamp(1, 100).notEquals(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) != 0",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) != 0",
-        "csharp": "new BsonTimestamp(1, 100) != new BsonTimestamp(2, 99)",
+        "csharp": "",
         "shell": "Timestamp(1, 100) !== Timestamp(2, 99)"
       },
       {
@@ -406,7 +404,7 @@
         "javascript": "Timestamp(1, 100).greaterThan(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) > 0",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) > 0",
-        "csharp": "new BsonTimestamp(1, 100) > new BsonTimestamp(2, 99)",
+        "csharp": "",
         "shell": "Timestamp(1, 100) > Timestamp(2, 99)"
       },
       {
@@ -414,7 +412,7 @@
         "javascript": "Timestamp(1, 100).greaterThanOrEqual(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) >= 0",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) >= 0",
-        "csharp": "new BsonTimestamp(1, 100) >= new BsonTimestamp(2, 99)",
+        "csharp": "",
         "shell": "Timestamp(1, 100) >= Timestamp(2, 99)"
       },
       {
@@ -422,7 +420,7 @@
         "javascript": "Timestamp(1, 100).lessThan(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) < 0",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) < 0",
-        "csharp": "new BsonTimestamp(1, 100) < new BsonTimestamp(2, 99)",
+        "csharp": "",
         "shell": "Timestamp(1, 100) < Timestamp(2, 99)"
       },
       {
@@ -430,7 +428,7 @@
         "javascript": "Timestamp(1, 100).lessThanOrEqual(Timestamp(2, 99))",
         "python": "(Timestamp(1, 100).time - Timestamp(2, 99).time) <= 0",
         "java": "new BSONTimestamp(1, 100).compareTo(new BSONTimestamp(2, 99)) <= 0",
-        "csharp": "new BsonTimestamp(1, 100) <= new BsonTimestamp(2, 99)",
+        "csharp": "",
         "shell": "Timestamp(1, 100) <= Timestamp(2, 99)"
       },
       {
@@ -438,7 +436,7 @@
         "javascript": "Timestamp(1, 100).getLowBits()",
         "python": "Timestamp(1, 100).time",
         "java": "new BSONTimestamp(1, 100).getTime()",
-        "csharp": "new BsonTimestamp(1, 100).ToUniversalTime()",
+        "csharp": "",
         "shell": "Timestamp(1, 100).getTime()"
       },
       {
@@ -446,7 +444,7 @@
         "javascript": "Timestamp(1, 100).getHighBits()",
         "python": "Timestamp(1, 100).inc",
         "java": "new BSONTimestamp(1, 100).getInc()",
-        "csharp": "new BsonTimestamp(1, 100).Increment",
+        "csharp": "",
         "shell": "Timestamp(1, 100).getInc()"
       }
     ],
@@ -456,7 +454,7 @@
         "javascript": "Symbol('2').valueOf()",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\").getSymbol()",
-        "csharp": "new BsonString(\"2\").AsBsonSymbol",
+        "csharp": "",
         "shell": "'2'"
       },
       {
@@ -464,7 +462,7 @@
         "javascript": "Symbol('2').toString()",
         "python": "str(unicode('2', 'utf-8'))",
         "java": "new Symbol(\"2\").toString()",
-        "csharp": "new BsonString(\"2\").ToString()",
+        "csharp": "",
         "shell": "'2'"
       },
       {
@@ -472,7 +470,7 @@
         "javascript": "Symbol('2').inspect()",
         "python": "unicode('2', 'utf-8')",
         "java": "new Symbol(\"2\").getSymbol()",
-        "csharp": "new BsonString(\"2\").Value",
+        "csharp": "",
         "shell": "'2'"
       }
     ]

--- a/test/json/success/javascript/bson-utils.json
+++ b/test/json/success/javascript/bson-utils.json
@@ -7,22 +7,22 @@
         "python": "ObjectId(u'5ab901c29ee65f5c8550c5b9')",
         "java": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\")",
         "shell": "ObjectId('5ab901c29ee65f5c8550c5b9')",
-        "csharp": "new ObjectId(\"5ab901c29ee65f5c8550c5b9\")"
+        "csharp": "
       },
       {
         "description": "createFromTime",
         "javascript": "ObjectId.createFromTime(1522075031642)",
         "python": "ObjectId.from_datetime(datetime.datetime.fromtimestamp(1522075031642/1000.0))",
         "java": "new ObjectId(new java.util.Date(new java.lang.Long(\"1522075031642\")))",
-        "shell": "ObjectId.fromDate(new Date(1522075031642))",
-        "csharp": "new ObjectId().GenerateNewId(Convert.ToInt32(1522075031642))"
+        "shell": "",
+        "csharp": "new BsonObjectId.GenerateNewId(1522075031642)"
       },
       {
         "description": "createFromTime with date",
         "javascript": "ObjectId.createFromTime(new Date())",
         "python": "ObjectId.from_datetime(datetime.datetime.fromtimestamp(datetime.datetime.utcnow().date()/1000.0))",
         "java": "new ObjectId(new java.util.Date())",
-        "csharp": "new ObjectId().GenerateNewId(DateTime.Now)",
+        "csharp": "",
         "shell": "ObjectId.fromDate(new Date())"
       },
       {
@@ -41,7 +41,7 @@
         "python": "bson.binary.BINARY_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.BINARY",
         "shell": "0",
-        "csharp": "BsonBinarySubType.Binary"
+        "csharp": ""
       },
       {
         "description": "subtype function",
@@ -49,7 +49,7 @@
         "python": "bson.binary.FUNCTION_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.FUNCTION",
         "shell": "1",
-        "csharp": "BsonBinarySubType.Function"
+        "csharp": ""
       },
       {
         "description": "subtype byte array",
@@ -57,7 +57,7 @@
         "python": "bson.binary.OLD_BINARY_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.OLD_BINARY",
         "shell": "2",
-        "csharp": "BsonBinarySubType.OldBinary"
+        "csharp": ""
       },
       {
         "description": "subtype uuid old",
@@ -65,7 +65,7 @@
         "python": "bson.binary.OLD_UUID_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.UUID_LEGACY",
         "shell": "3",
-        "csharp": "BsonBinarySubType.UuidLegacy"
+        "csharp": ""
       },
       {
         "description": "subtype uuid",
@@ -73,7 +73,7 @@
         "python": "bson.binary.UUID_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.UUID_STANDARD",
         "shell": "4",
-        "csharp": "BsonBinarySubType.UuidStandard"
+        "csharp": ""
       },
       {
         "description": "subtype md5",
@@ -81,7 +81,7 @@
         "python": "bson.binary.MD5_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.MD5",
         "shell": "5",
-        "csharp": "BsonBinarySubType.MD5"
+        "csharp": ""
       },
       {
         "description": "subtype udef",
@@ -89,7 +89,7 @@
         "python": "bson.binary.USER_DEFINED_SUBTYPE",
         "java": "org.bson.BsonBinarySubType.USER_DEFINED",
         "shell": "80",
-        "csharp": "BsonBinarySubType.UserDefined"
+        "csharp": ""
       }
     ],
     "Long": [
@@ -99,7 +99,7 @@
         "python": "sys.maxsize",
         "java": "java.lang.Long.MAX_VALUE",
         "shell": "math.max()",
-        "csharp": "Int64.MaxValue"
+        "csharp": ""
       },
       {
         "description": "MIN_VALUE",
@@ -107,7 +107,7 @@
         "python": "-sys.maxsize -1",
         "java": "java.lang.Long.MIN_VALUE",
         "shell": "math.min()",
-        "csharp": "Int64.MinValue"
+        "csharp": ""
       },
       {
         "description": "ZERO",
@@ -115,7 +115,7 @@
         "python": "Int64(0)",
         "java": "new java.lang.Long(0)",
         "shell": "0",
-        "csharp": "new BsonInt64(0)"
+        "csharp": ""
       },
       {
         "description": "ONE",
@@ -123,7 +123,7 @@
         "python": "Int64(1)",
         "java": "new java.lang.Long(1)",
         "shell": "1",
-        "csharp": "new BsonInt64(1)"
+        "csharp": ""
       },
       {
         "description": "NEG_ONE",
@@ -131,7 +131,7 @@
         "python": "Int64(-1)",
         "java": "new java.lang.Long(-1)",
         "shell": "-1",
-        "csharp": "new BsonInt64(-1)"
+        "csharp": ""
       },
       {
         "description": "fromInt",
@@ -139,7 +139,7 @@
         "python": "Int64(5)",
         "java": "new java.lang.Long(\"5\")",
         "shell": "NumberLong(5)",
-        "csharp": "new BsonInt64(5)"
+        "csharp": ""
       },
       {
         "description": "fromString without radix",
@@ -147,7 +147,7 @@
         "python": "Int64(int('5'))",
         "java": "java.lang.Long.parseLong(\"5\")",
         "shell": "NumberLong('5')",
-        "csharp": "new BsonInt64(5)"
+        "csharp": ""
       },
       {
         "description": "fromString with radix",
@@ -155,7 +155,7 @@
         "python": "Int64(int('5'))",
         "java": "java.lang.Long.parseLong(\"5\", 10)",
         "shell": "NumberLong('5')",
-        "csharp": "Convert.ToInt64(\"5\", 10)"
+        "csharp": ""
       },
       {
         "description": "fromBits",
@@ -163,7 +163,7 @@
         "python": "Int64(9223372036854775807)",
         "java": "new java.lang.Long(\"9223372036854775807\")",
         "shell": "NumberLong(2147483647)",
-        "csharp": "new BsonInt64(9223372036854775807)"
+        "csharp": ""
       }
     ],
     "Decimal128": [
@@ -173,7 +173,7 @@
         "python": "Decimal128('5')",
         "java": "Decimal128.parse(\"5\")",
         "shell": "NumberDecimal('5')",
-        "csharp": "new Decimal128(5)"
+        "csharp": ""
       }
     ]
   }

--- a/test/json/success/javascript/language-types.json
+++ b/test/json/success/javascript/language-types.json
@@ -6,7 +6,7 @@
         "javascript": "2+5",
         "python": "2+5",
         "java": "new java.lang.Long(\"2\")+new java.lang.Long(\"5\")",
-        "csharp": "2+5",
+        "csharp": "",
         "shell": "2+5"
       },
       {
@@ -14,7 +14,7 @@
         "javascript": "2+(4*36)/3",
         "python": "2+(4*36)/3",
         "java": "new java.lang.Long(\"2\")+(new java.lang.Long(\"4\")*new java.lang.Long(\"36\"))/new java.lang.Long(\"3\")",
-        "csharp": "2+(4*36)/3",
+        "csharp": "",
         "shell": "2+(4*36)/3"
       }
     ],
@@ -24,7 +24,7 @@
         "javascript": "new Number(2)",
         "python": "int(2)",
         "java": "new java.lang.Long(\"2\")",
-        "csharp": "(int)2",
+        "csharp": "",
         "shell": "new Number(2)"
       },
       {
@@ -32,7 +32,7 @@
         "javascript": "new Number('2')",
         "python": "int('2')",
         "java": "new java.lang.Long(\"2\")",
-        "csharp": "(int)2",
+        "csharp": "",
         "shell": "Number('2')"
       }
     ],
@@ -42,7 +42,7 @@
         "javascript": "2",
         "python": "2",
         "java": "new java.lang.Long(\"2\")",
-        "csharp": "2",
+        "csharp": "",
         "shell": "2"
       },
       {
@@ -50,7 +50,7 @@
         "javascript": "429496729601",
         "python": "429496729601",
         "java": "new java.lang.Long(\"429496729601\")",
-        "csharp": "429496729601",
+        "csharp": "",
         "shell": "429496729601"
       },
       {
@@ -58,7 +58,7 @@
         "javascript": "2.001",
         "python": "2.001",
         "java": "new java.lang.Double(2.001)",
-        "csharp": "2.001",
+        "csharp": "",
         "shell": "2.001"
       },
       {
@@ -66,7 +66,7 @@
         "javascript": "0X123ABC",
         "python": "0X123ABC",
         "java": "0X123ABC",
-        "csharp": "0X123ABC",
+        "csharp": "",
         "shell": "0X123ABC"
       },
       {
@@ -74,7 +74,7 @@
         "javascript": "0x123abc",
         "python": "0x123abc",
         "java": "0x123abc",
-        "csharp": "0x123abc",
+        "csharp": "",
         "shell": "0x123abc"
       },
       {
@@ -82,7 +82,7 @@
         "javascript": "01234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": "342391",
+        "csharp": "",
         "shell": "01234567"
       },
       {
@@ -90,7 +90,7 @@
         "javascript": "001234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": "342391",
+        "csharp": "",
         "shell": "0o1234567"
       },
       {
@@ -98,7 +98,7 @@
         "javascript": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": "342391",
+        "csharp": "",
         "shell": "0o1234567"
       },
       {
@@ -106,7 +106,7 @@
         "javascript": "0o1234567",
         "python": "0o1234567",
         "java": "01234567",
-        "csharp": "342391",
+        "csharp": "",
         "shell": "0o1234567"
       },
       {
@@ -114,7 +114,7 @@
         "javascript": "'string'",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": "\"string\"",
+        "csharp": "",
         "shell": "'string'"
       },
       {
@@ -122,7 +122,7 @@
         "javascript": "\"string\"",
         "python": "'string'",
         "java": "\"string\"",
-        "csharp": "\"string\"",
+        "csharp": "",
         "shell": "\"string\""
       },
       {
@@ -130,7 +130,7 @@
         "javascript": "null",
         "python": "None",
         "java": "null",
-        "csharp": "BsonNull.Value",
+        "csharp": "",
         "shell": "null"
       },
       {
@@ -138,7 +138,7 @@
         "javascript": "undefined",
         "python": "None",
         "java": "null",
-        "csharp": "BsonUndefined.Value",
+        "csharp": "",
         "shell": "undefined"
       },
       {
@@ -146,7 +146,7 @@
         "javascript": "true",
         "python": "True",
         "java": "true",
-        "csharp": "true",
+        "csharp": "",
         "shell": "true"
       },
       {
@@ -154,7 +154,7 @@
         "javascript": "false",
         "python": "False",
         "java": "false",
-        "csharp": "false",
+        "csharp": "",
         "shell": "false"
       }
     ],
@@ -164,7 +164,7 @@
         "javascript": "new Date('December 17, 1995 03:24:00Z')",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(new java.lang.Long(\"819170640000\"))",
-        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)",
+        "csharp": "",
         "shell": "new Date('December 17, 1995 03:24:00Z')"
       },
       {
@@ -172,7 +172,7 @@
         "javascript": "new Date(819167040000)",
         "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(new java.lang.Long(\"819167040000\"))",
-        "csharp": "new DateTime(1995, 12, 17, 2, 24, 0)",
+        "csharp": "",
         "shell": "new Date(819167040000)"
       },
       {
@@ -180,7 +180,7 @@
         "javascript": "new Date()",
         "python": "datetime.datetime.utcnow().date()",
         "java": "new java.util.Date()",
-        "csharp": "DateTime.Now",
+        "csharp": "",
         "shell": "new Date()"
       },
       {
@@ -188,7 +188,7 @@
         "javascript": "new Date(1995, 11, 17)",
         "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(new java.lang.Long(\"819158400000\"))",
-        "csharp": "new DateTime(1995, 12, 17, 0, 0, 0)",
+        "csharp": "",
         "shell": "new Date(1995, 11, 17)"
       },
       {
@@ -196,7 +196,7 @@
         "javascript": "new Date(1995, 11, 17, 3, 24, 0)",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc)",
         "java": "new java.util.Date(new java.lang.Long(\"819170640000\"))",
-        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0)",
+        "csharp": "",
         "shell": "new Date(1995, 11, 17, 3, 24, 0)"
       },
       {
@@ -204,7 +204,7 @@
         "javascript": "Date('December 17, 1995 03:24:00Z')",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc).strftime('%a %b %d %Y %H:%M:%S %Z')",
         "java": "new java.util.Date(new java.lang.Long(\"819170640000\")).toString()",
-        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0).ToString()",
+        "csharp": "",
         "shell": "Date('December 17, 1995 03:24:00Z')"
       },
       {
@@ -212,7 +212,7 @@
         "javascript": "Date(819167040000)",
         "python": "datetime.datetime(1995, 12, 17, 2, 24, 0, tzinfo=datetime.timezone.utc).strftime('%a %b %d %Y %H:%M:%S %Z')",
         "java": "new java.util.Date(new java.lang.Long(\"819167040000\")).toString()",
-        "csharp": "new DateTime(1995, 12, 17, 2, 24, 0).ToString()",
+        "csharp": "",
         "shell": "Date(819167040000)"
       },
       {
@@ -220,7 +220,7 @@
         "javascript": "Date()",
         "python": "datetime.datetime.utcnow().date().strftime('%a %b %d %Y %H:%M:%S %Z')",
         "java": "new java.util.Date().toString()",
-        "csharp": "DateTime.Now.ToString()",
+        "csharp": "",
         "shell": "Date()"
       },
       {
@@ -228,7 +228,7 @@
         "javascript": "Date(1995, 11, 17)",
         "python": "datetime.datetime(1995, 12, 17, 0, 0, 0, tzinfo=datetime.timezone.utc).strftime('%a %b %d %Y %H:%M:%S %Z')",
         "java": "new java.util.Date(new java.lang.Long(\"819158400000\")).toString()",
-        "csharp": "new DateTime(1995, 12, 17, 0, 0, 0).ToString()",
+        "csharp": "",
         "shell": "Date(1995, 11, 17)"
       },
       {
@@ -236,7 +236,7 @@
         "javascript": "Date(1995, 11, 17, 3, 24, 0)",
         "python": "datetime.datetime(1995, 12, 17, 3, 24, 0, tzinfo=datetime.timezone.utc).strftime('%a %b %d %Y %H:%M:%S %Z')",
         "java": "new java.util.Date(new java.lang.Long(\"819170640000\")).toString()",
-        "csharp": "new DateTime(1995, 12, 17, 3, 24, 0).ToString()",
+        "csharp": "",
         "shell": "Date(1995, 11, 17, 3, 24, 0)"
       },
       {
@@ -244,7 +244,7 @@
         "javascript": "Date.now()",
         "python": "datetime.datetime.utcnow()",
         "java": "new java.util.Date()",
-        "csharp": "DateTime.Now",
+        "csharp": "",
         "shell": "Date.now()"
       }
     ],
@@ -254,7 +254,7 @@
         "javascript": "RegExp('')",
         "python": "re.compile(r\"(?:)\")",
         "java": "Pattern.compile(\"(?:)\")",
-        "csharp": "new Regex(\"(?:)\")",
+        "csharp": "",
         "shell": "RegExp('')"
       },
       {
@@ -262,7 +262,7 @@
         "javascript": "RegExp('abc')",
         "python": "re.compile(r\"abc\")",
         "java": "Pattern.compile(\"abc\")",
-        "csharp": "new Regex(\"abc\")",
+        "csharp": "",
         "shell": "RegExp('abc')"
       },
       {
@@ -270,7 +270,7 @@
         "javascript": "new RegExp('ab+c', 'im')",
         "python": "re.compile(r\"ab+c(?im)\")",
         "java": "Pattern.compile(\"ab+c(?im)\")",
-        "csharp": "new Regex(\"(?im)ab+c\")",
+        "csharp": "",
         "shell": "new RegExp('ab+c', 'im')"
       },
       {
@@ -278,7 +278,7 @@
         "javascript": "new RegExp('ab+c', 'ig')",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": "new Regex(\"(?i)ab+c\")",
+        "csharp": "",
         "shell": "new RegExp('ab+c', 'ig')"
       },
       {
@@ -286,7 +286,7 @@
         "javascript": "new RegExp('ab/cd')",
         "python": "re.compile(r\"ab\\/cd\")",
         "java": "Pattern.compile(\"ab\\\\/cd\")",
-        "csharp": "new Regex(\"ab\\/cd\")",
+        "csharp": "",
         "shell": "new RegExp('ab/cd')"
       },
       {
@@ -294,7 +294,7 @@
         "javascript": "new RegExp('ab\\\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
-        "csharp": "new Regex(\"ab\\\"ab\")",
+        "csharp": "",
         "shell": "new RegExp('ab\\\"ab')"
       },
       {
@@ -302,7 +302,7 @@
         "javascript": "new RegExp('ab\"ab')",
         "python": "re.compile(r\"ab\\\"ab\")",
         "java": "Pattern.compile(\"ab\\\"ab\")",
-        "csharp": "new Regex(\"ab\\\"ab\")",
+        "csharp": "",
         "shell": "new RegExp('ab\"ab')"
       },
       {
@@ -310,7 +310,7 @@
         "javascript": "new RegExp('ab\\'ab')",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
-        "csharp": "new Regex(\"ab'ab\")",
+        "csharp": "",
         "shell": "new RegExp('ab\\'ab')"
       },
       {
@@ -318,7 +318,7 @@
         "javascript": "new RegExp(\"ab'ab\")",
         "python": "re.compile(r\"ab'ab\")",
         "java": "Pattern.compile(\"ab'ab\")",
-        "csharp": "new Regex(\"ab'ab\")",
+        "csharp": "",
         "shell": "new RegExp(\"ab'ab\")"
       },
       {
@@ -326,7 +326,7 @@
         "javascript": "new RegExp(\"\\\\n\")",
         "python": "re.compile(r\"\\\\n\")",
         "java": "Pattern.compile(\"\\\\n\")",
-        "csharp": "new Regex(\"\\n\")",
+        "csharp": "",
         "shell": "new RegExp(\"\\\\n\")"
       },
       {
@@ -334,7 +334,7 @@
         "javascript": "/ab+c/ig",
         "python": "re.compile(r\"ab+c(?is)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": "new Regex(\"(?i)ab+c\")",
+        "csharp": "",
         "shell": "/ab+c/ig"
       },
       {
@@ -342,7 +342,7 @@
         "javascript": "new RegExp(/ab+c/, 'i')",
         "python": "re.compile(r\"ab+c(?i)\")",
         "java": "Pattern.compile(\"ab+c(?i)\")",
-        "csharp": "new Regex(\"(?i)ab+c\")",
+        "csharp": "",
         "shell": "new RegExp(/ab+c/, 'i')"
       }
     ]


### PR DESCRIPTION
(third time is a charm)

This branch is meant to create a good-ish readable diff to our tests for `c#` so the output can be verified. The main chunk of verification should happen in the t`est/json/success/javascript`, but everything else is fair game too.

I will comment out the code I have specific questions about, which will hopefully make this easier to read. Some will be language specific (never written `c#` in my life before this), and the others are driver specific, such as things I couldn't quite figure out from documentation.

The TL;DR of what these tests are doing is checking whether javascript code is correctly generated for the applicable language (this case `c#`).

I couldn't get the PR to work properly the proper way around, so the **RED** represents the c# output (rather than the expected green).