### PR TITLE
accept env variables as output/input params

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "eslint-config-mongodb-js": "^2.1.0",
-    "pre-commit": "^1.2.2",
-    "mongodb-js-precommit": "^0.2.8"
+    "mongodb-js-precommit": "^0.2.8",
+    "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "antlr4": "^4.7.1",

--- a/test/code-generation.test.js
+++ b/test/code-generation.test.js
@@ -1,12 +1,10 @@
 /* eslint no-sync: 0 */
-const {
-  readJSON,
-  runTest,
-  inputLanguages,
-  outputLanguages
-} = require('./helpers');
-const fs = require('fs');
+const { readJSON, runTest } = require('./helpers');
 const path = require('path');
+const fs = require('fs');
+
+const outputLanguages = process.env.OUTPUT ? process.env.OUTPUT.split(',') : [ 'csharp', 'python', 'java', 'javascript', 'shell'];
+const inputLanguages = process.env.INPUT ? process.env.INPUT.split(',') : [ 'shell', 'javascript' ];
 
 describe('Test', () => {
   const pSuccess = path.join(__dirname, 'json', 'success');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,9 +6,6 @@ const expect = chai.expect;
 
 const compiler = require('../');
 
-// Need a way to have test pass while developing
-const outputLanguages = ['csharp', 'python', 'java', 'javascript', 'shell'];
-const inputLanguages = ['shell', 'javascript'];
 const unsupported = {
   success: {
     javascript: {
@@ -93,4 +90,4 @@ const runTest = function(mode, testname, inputLang, outputLang, tests) {
   });
 };
 
-module.exports = {inputLanguages, outputLanguages, readJSON, runTest};
+module.exports = {readJSON, runTest};


### PR DESCRIPTION
allows for us to run tests individually for each input/output language.

The way to use this is:

```shell
$ OUTPUT=python,java INPUT=javascript npm run test
```

If none are provided, will default to everything we have. Probably for most cases we'd only be ever doing one input and one output, or everything all together so I think this is a nice quick approach to speed up testing.