### PR TITLE
Add import string as export

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,20 @@ const string =`
 
 const compiledString = compiler[input][output](string);
 console.log(compiledCode)
-// new Document().append("item", "book").append("qty", new Binary("5".getBytes("UTF-8")))
+// new Document("item", "book").append("qty", new Binary("5".getBytes("UTF-8")))
 // .append("tags", Arrays.asList("red", "blank"))
-// .append("dim_cm", Arrays.asList(new java.lang.Long("14"), new java.lang.Integer("81")))  
+// .append("dim_cm", Arrays.asList(14L, 81")))
 ```
 
 ## API
-### compiledString = compiler.inputLang.outputLang(codeString)
+### compiledString = compiler\[inputLang\]\[outputLang\](codeString)
 Output a compiled string given input and output languages.
 - __inputLang:__ Input language of the code string. `shell` and `javascript` are currently supported.
-- __outputLang:__ The language you would like the output to be. `java`, `python` and `C#` are currently supported.
+- __outputLang:__ The language you would like the output to be. `java`, `python` and `csharp` are currently supported.
 - __codeString:__ The code string you would like to be compiled to your selected output language.
 
+### importsString = compiler.imports[outputLang]
+Output a string containing the set of import statements for the generated code to compile. These are all the packages that the compiled code could use so that the compiler output will be runnable. May include unused imports if the input string doesn't use a specific type.
 # Install
 ```shell
 npm install -S bson-compilers

--- a/index.js
+++ b/index.js
@@ -65,6 +65,26 @@ const getCompiler = (visitor, generator, symbols) => {
   };
 };
 
+const javaImports = `
+package com.example.test;
+
+import com.mongodb.DBRef;
+import org.bson.BsonBinarySubType;
+import org.bson.BsonRegularExpression;
+import org.bson.Document;
+import org.bson.types.*;
+import org.bson.BsonUndefined;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+`;
+
+const pythonImports = `
+from bson import *
+import datetime
+`;
+
 
 module.exports = {
   javascript: {
@@ -78,6 +98,13 @@ module.exports = {
     python: getCompiler(ShellVisitor, PythonGenerator, shellpythonsymbols),
     csharp: getCompiler(ShellVisitor, CsharpGenerator, shellcsharpsymbols),
     javascript: getCompiler(ShellVisitor, JavascriptGenerator, shelljavascriptsymbols)
+  },
+  imports: {
+    java: javaImports,
+    python: pythonImports,
+    csharp: '', // TODO
+    javascript: '',
+    shell: ''
   },
   getTree: loadTree
 };

--- a/index.js
+++ b/index.js
@@ -85,6 +85,32 @@ from bson import *
 import datetime
 `;
 
+const csharpImports = `
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+using System;
+using System.Text.RegularExpressions;
+`;
+
+const javascriptImports = `
+const {
+  Binary,
+  Code,
+  ObjectId,
+  DBRef,
+  Int32,
+  Double,
+  Long,
+  Decimal128,
+  MinKey,
+  MaxKey,
+  BSONRegExp,
+  Timestamp,
+  Symbol
+} = require('mongodb');
+`;
+
 
 module.exports = {
   javascript: {
@@ -102,8 +128,8 @@ module.exports = {
   imports: {
     java: javaImports,
     python: pythonImports,
-    csharp: '', // TODO
-    javascript: '',
+    csharp: csharpImports,
+    javascript: javascriptImports,
     shell: ''
   },
   getTree: loadTree


### PR DESCRIPTION
Each language exports a string including the required imports now. Can be used in the UI to indicate which packages are being used.

Currently, doesn't do anything "smart", and just lists all the packages that can be used. In the future we could add detection for classes that are getting used and only show imports for those classes, but for now we import everything.

TODO: make sure we're importing in the most 'idiomatic' way.