### PR TITLE
Allow running test by mode

### DIFF
--- a/test/code-generation.test.js
+++ b/test/code-generation.test.js
@@ -5,29 +5,19 @@ const fs = require('fs');
 
 const outputLanguages = process.env.OUTPUT ? process.env.OUTPUT.split(',') : [ 'csharp', 'python', 'java', 'javascript', 'shell'];
 const inputLanguages = process.env.INPUT ? process.env.INPUT.split(',') : [ 'shell', 'javascript' ];
+const modes = process.env.MODE ? process.env.MODE.split(',') : ['success', 'error'];
 
 describe('Test', () => {
-  const pSuccess = path.join(__dirname, 'json', 'success');
-  const pError = path.join(__dirname, 'json', 'error');
+  modes.forEach((mode) => {
+    const testpath = path.join(__dirname, 'json', mode);
+    inputLanguages.forEach((inputLang) => {
+      fs.readdirSync(path.join(testpath, inputLang)).map((file) => {
+        const tests = readJSON(path.join(testpath, inputLang, file)).tests;
+        const testname = file.replace('.json', '');
 
-  inputLanguages.forEach((inputLang) => {
-    fs.readdirSync(path.join(pSuccess, inputLang)).map((file) => {
-      const tests = readJSON(path.join(pSuccess, inputLang, file)).tests;
-      const testname = file.replace('.json', '');
-
-      outputLanguages.forEach((outputLang) => {
-        runTest('success', testname, inputLang, outputLang, tests);
-      });
-    });
-  });
-
-  inputLanguages.forEach((inputLang) => {
-    fs.readdirSync(path.join(pError, inputLang)).map((file) => {
-      const tests = readJSON(path.join(pError, inputLang, file)).tests;
-      const testname = file.replace('.json', '');
-
-      outputLanguages.forEach((outputLang) => {
-        runTest('error', testname, inputLang, outputLang, tests);
+        outputLanguages.forEach((outputLang) => {
+          runTest(mode, testname, inputLang, outputLang, tests);
+        });
       });
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,6 +21,9 @@ const checkResults = {
       compiler[inputLang][outputLang](test.query);
     } catch (error) {
       expect(error.code).to.equal(test.errorCode);
+      if (test.message) {
+        expect(error.message.contains(test.message)).to.be.true;
+      }
     }
   }
 };


### PR DESCRIPTION
Can set MODE env var to "success" or "error" so that we don't have to run the whole test suite if we're just testing errors.

Also adds an optional error message field if we want to test the error message contains some string. I want this because I'm writing "unimplemented" errors and I want to make sure that the error messages are getting generated correctly.