### PR TITLE
bump node to 9.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 8.2
+  - 9.8.0
 install: npm install --ignore-scripts
 script: npm run ci
 cache:


### PR DESCRIPTION
tests take *forever* to run on  node`8.2.0`. bumping it to `9.8.0` cause it's a lot faster o.O