### PR TITLE
remove initial \n in import strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,7 @@ const getCompiler = (visitor, generator, symbols) => {
   };
 };
 
-const javaImports = `
-package com.example.test;
+const javaImports = `package com.example.test;
 
 import com.mongodb.DBRef;
 import org.bson.BsonBinarySubType;
@@ -90,21 +89,18 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 `;
 
-const pythonImports = `
-from bson import *
+const pythonImports = `from bson import *
 import datetime
 `;
 
-const csharpImports = `
-using MongoDB.Bson;
+const csharpImports = `using MongoDB.Bson;
 using MongoDB.Driver;
 
 using System;
 using System.Text.RegularExpressions;
 `;
 
-const javascriptImports = `
-const {
+const javascriptImports = `const {
   Binary,
   Code,
   ObjectId,


### PR DESCRIPTION
import strings all have a starting new line break which shouldn't be there for the UI portion of things. Removing it for now so I don't have to strip it in the UI.