### PR TITLE
Support for using Java generators.

### DIFF
--- a/codegeneration/java/Generator.js
+++ b/codegeneration/java/Generator.js
@@ -1,5 +1,8 @@
 /* eslint complexity: 0 */
 const {doubleQuoteStringify} = require('../../helper/format');
+const {
+  BsonCompilersRuntimeError
+} = require('../../helper/error');
 
 /**
  * @param {class} superClass - where the `visitX` methods live.
@@ -15,6 +18,19 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
     this.bsonRegexFlags = {
       i: 'i', m: 'm', x: 'x', s: 's', l: 'l', u: 'u'
     };
+    // Operations that take the field name as an argument
+    this.field_opts = [
+      'gt', 'lt', 'lte', 'gte', 'eq', 'ne', 'nin', 'in', 'not', 'exists',
+      'type', 'all', 'size', 'elemMatch', 'mod', 'regex',
+      'sum', 'avg', 'first', 'last', 'max', 'min', 'push', 'addToSet',
+      'stdDevSamp', 'stdDevPop',
+      'bitsAllSet', 'bitsAllClear', 'bitsAnySet', 'bitsAnyClear'
+    ];
+    // Operations that convert by {$op: value} => op(value)
+    this.opts = [
+      'match', 'skip', 'limit', 'out', 'sortByCount', 'count', 'or', 'nor',
+      'and'
+    ];
   }
 
   /**
@@ -80,7 +96,9 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
    * @return {String}
    */
   emitObjectIdCreateFromTime(ctx) {
-    ctx.type = 'createFromTime' in this.Symbols.ObjectId.attr ? this.Symbols.ObjectId.attr.createFromTime : this.Symbols.ObjectId.attr.fromDate;
+    ctx.type = 'createFromTime' in this.Symbols.ObjectId.attr ?
+      this.Symbols.ObjectId.attr.createFromTime :
+      this.Symbols.ObjectId.attr.fromDate;
     const argList = ctx.arguments().argumentList();
     const args = this.checkArguments(ctx.type.args, argList);
     const template = ctx.type.template ? ctx.type.template() : '';
@@ -91,4 +109,526 @@ module.exports = (superClass) => class ExtendedVisitor extends superClass {
       '', `new java.util.Date(${args[0]})`)}`;
   }
 
+
+  /**
+   * Emit an "idiomatic" filter or aggregation, meaning use the builders
+   * instead of a regular object if possible.
+   *
+   * @param {ObjectLiteralContext} ctx
+   * @return {String}
+   */
+  emitIdiomaticObjectLiteral(ctx) {
+    ctx.type = this.Types._object;
+    ctx.indentDepth = this.getIndentDepth(ctx) + 1;
+    let multiOps = false;
+    let args = '';
+    if (ctx.propertyNameAndValueList()) {
+      const properties = ctx.propertyNameAndValueList().propertyAssignment();
+      args = properties.map((pair) => {
+        const field = this.visit(pair.propertyName());
+        if (field.startsWith('$')) {
+          const op = field.substr(1);
+          if (op === 'regex') {
+            multiOps = true;
+          }
+          if (`handle${op}` in this) {
+            return this[`handle${op}`](
+              pair.singleExpression().getChild(0), op, ctx
+            );
+          }
+          if (this.field_opts.indexOf(op) !== -1) {
+            return this.handleFieldOp(pair.singleExpression(), op, ctx);
+          }
+          if (this.opts.indexOf(op) !== -1) {
+            return `${field.substr(1)}(${this.visit(pair.singleExpression())})`;
+          }
+        }
+        const value = this.visit(pair.singleExpression());
+        // $-op filters need to rewind a level
+        if (this.isFilter(pair.singleExpression().getChild(0))) {
+          return value;
+        }
+        return `eq(${doubleQuoteStringify(field)}, ${value})`;
+      });
+      if (args.length > 1 && !multiOps) {
+        return `and(${args.join(', ')})`;
+      }
+      return args[0];
+    }
+    return 'new Document()';
+  }
+
+  /**
+   * Generates idiomatic java for a $-operator that takes the field name
+   * as the first argument. i.e. { field: { $op: value } } => op(field, value)
+   *
+   * @param {ObjectLiteralContext} ctx - The field of the $-op
+   * @param {String} op - The $-op
+   * @param {ObjectLiteralContext} parent - The parent object's ctx
+   * @returns {String}
+   */
+  handleFieldOp(ctx, op, parent) {
+    const parentField = this.visit(parent.parentCtx.parentCtx.propertyName());
+    return `${op}(${doubleQuoteStringify(parentField)}, ${this.visit(ctx)})`;
+  }
+
+  /**
+   * Determines if an object has a subfield that is a $-op.
+   *
+   * @param {ObjectLiteralContext} ctx - The field of the $-op
+   * @return {Boolean}
+   */
+  isFilter(ctx) {
+    if ('propertyNameAndValueList' in ctx && ctx.propertyNameAndValueList()) {
+      const properties = ctx.propertyNameAndValueList().propertyAssignment();
+      for (let i = 0; i < properties.length; i++) {
+        const pair = properties[i];
+        const field = this.visit(pair.propertyName());
+        if (this.field_opts.indexOf(field.substr(1)) !== -1) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Generates idiomatic java for a $-operator that requires a document that has
+   * a single subfield whose value gets set to the builder argument.
+   * { $op: { $subfield: value } } => op(value)
+   *
+   * @param {ObjectLiteralContext} ctx - The field of the $-op
+   * @param {String} op - The name of the $-op.
+   * @param {String} subfield - The name of the subfield to require.
+   * @param {Boolean} idiomatic - If the value should be generated as idiomatic.
+   * @return {String}
+   */
+  handleSingleSubfield(ctx, op, subfield, idiomatic) {
+    if (!('propertyNameAndValueList' in ctx) ||
+        !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        `$${op} requires a non-empty document`
+      );
+    }
+    let value = '';
+    const properties = ctx.propertyNameAndValueList().propertyAssignment();
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      if (field === subfield) {
+        this.idiomatic = idiomatic;
+        value = this.visit(pair.singleExpression());
+        this.idiomatic = true;
+      } else {
+        throw new BsonCompilersRuntimeError(
+          `Unrecognized option to $${op}: ${field}`
+        );
+      }
+    });
+    if (value === '') {
+      throw new BsonCompilersRuntimeError(
+        `Missing option '${subfield}' in $${op}`
+      );
+    }
+    return `${op}(${value})`;
+  }
+
+  /**
+   * Generates idiomatic java for a $-operator that has some required options
+   * and some options that get rolled into an Options object.
+   *
+   * { $op: { required: reqVal, optional: optionalVal } =>
+   * op(reqVal, new Options.optional())
+   *
+   * @param {ObjectLiteralContext} ctx - The field of the $-op
+   * @param {String} op - The name of the $-op.
+   * @param {Array} reqOpts - The list of required options.
+   * @param {Array} optionalOpts - The list of optional options.
+   * @param {Object} transforms - An mapping of original name to transformed
+   * name. Includes both optional options and the Options object.
+   * @return {string}
+   */
+  handleOptionsObject(ctx, op, reqOpts, optionalOpts, transforms) {
+    if (!('propertyNameAndValueList' in ctx) ||
+        !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        `$${op} requires a non-empty document`
+      );
+    }
+    const fields = {};
+
+    const properties = ctx.propertyNameAndValueList().propertyAssignment();
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      if (reqOpts.indexOf(field) !== -1 || optionalOpts.indexOf(field) !== -1) {
+        fields[field] = this.visit(pair.singleExpression());
+      } else {
+        throw new BsonCompilersRuntimeError(
+          `Unrecognized option to $${op}: ${field}`
+        );
+      }
+    });
+    reqOpts.map((f) => {
+      if (!(f in fields)) {
+        throw new BsonCompilersRuntimeError(`Missing option '${f}' in $${op}`);
+      }
+    });
+
+    let options = '';
+    if (Object.keys(fields).length > reqOpts.length) {
+      options = `, new ${transforms[op]}()${Object.keys(fields).filter((f) => {
+        return optionalOpts.indexOf(f) !== -1;
+      }).map((k) => {
+        if (transforms !== undefined && k in transforms) {
+          return transforms[k](fields[k]);
+        }
+        return `.${k}(${fields[k]})`;
+      }).join('')}`;
+    }
+
+    return `${op}(${reqOpts.map((f) => {
+      return fields[f];
+    }).join(', ')}${options})`;
+  }
+
+  /**
+   * Generates idiomatic java for a $-operator that has some required options
+   * and then multiple arbitrary fields.
+   *
+   * { $op: { required: reqVal, opt1: v1, opt2: v2...} } => op(reqVal, v1, v2...)
+   * @param {ObjectLiteralContext} ctx - The field of the $-op
+   * @param {String} op - The name of the $-op.
+   * @param {Array} reqOpts - The list of required options.
+   * @param {Function} transform - A function that takes in the option name and
+   * the value, then returns a string with the correct formatting.
+   * @param {Boolean} idiomatic - If the value should be generated as idiomatic.
+   * @return {string}
+   */
+  handleMultipleArgs(ctx, op, reqOpts, transform, idiomatic) {
+    if (!('propertyNameAndValueList' in ctx) ||
+        !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        `$${op} requires a non-empty document`
+      );
+    }
+    const req = [];
+    const fields = {};
+    const properties = ctx.propertyNameAndValueList().propertyAssignment();
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      if (reqOpts.indexOf(field) !== -1) {
+        req.push(this.visit(pair.singleExpression()));
+      } else {
+        this.idiomatic = idiomatic;
+        fields[field] = this.visit(pair.singleExpression());
+        this.idiomatic = true;
+      }
+    });
+    if (req.length !== reqOpts.length) {
+      throw new BsonCompilersRuntimeError(
+        `Required option missing from ${op}`
+      );
+    }
+
+    const args = req.concat(Object.keys(fields).map((f) => {
+      return transform(f, fields[f]);
+    }));
+    return `${op}(${args.join(', ')})`;
+  }
+
+  /**
+   * Method for handling an idiomatic $project.
+   * ctx must be a non-empty document.
+   *
+   * @param {ObjectLiteralContext} ctx
+   * @return {String}
+   */
+  handleproject(ctx) {
+    // TODO: slice and elemMatch
+    if (!('propertyNameAndValueList' in ctx) ||
+        !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        '$project requires a non-empty document'
+      );
+    }
+    const properties = ctx.propertyNameAndValueList().propertyAssignment();
+    const fields = {};
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      const original = pair.singleExpression().getText();
+      if (original === 'true' || original === '1') {
+        if (field !== '_id') {
+          // Skip because ID is included by default
+          fields.includes = !fields.includes ?
+            `include(${doubleQuoteStringify(field)}` :
+            `${fields.includes}, ${doubleQuoteStringify(field)}`;
+        }
+      } else if (original === 'false' || original === '0') {
+        if (field !== '_id') {
+          fields.excludes = !fields.excludes ?
+            `exclude(${doubleQuoteStringify(field)}` :
+            `${fields.excludes}, ${doubleQuoteStringify(field)}`;
+        } else {
+          fields.excludeId = 'excludeId()';
+        }
+      } else {
+        const value = this.visit(pair.singleExpression());
+        fields.computed = !fields.computed ?
+          `computed(${doubleQuoteStringify(field)}, ${value})` :
+          `${fields.computed}, computed(${doubleQuoteStringify(field)}, ${value})`;
+      }
+    });
+
+    if (fields.includes) {
+      fields.includes = `${fields.includes})`;
+    }
+    if (fields.excludes) {
+      fields.excludes = `${fields.excludes})`;
+    }
+    const elements = Object.values(fields);
+    const fieldsstr = elements.length === 1 ?
+      `${elements[0]}` :
+      `fields(${elements.join(', ')})`;
+    return `project(${fieldsstr})`;
+  }
+
+  /**
+   * Method for handling an idiomatic $not.
+   *
+   * { field: { $not: {$op: value} } } => not(op(field, value))
+   *
+   * ctx must be a non-empty document.
+   *
+   * @param {ObjectLiteralExpressionContext} ctx - the ctx of the value of the
+   * $not field
+   * @param {String} op - the operation, which in this case is "not"
+   * @param {ObjectLiteralExpressionContext} parent - ctx of parent document.
+   * @return {String}
+   */
+  handlenot(ctx, op, parent) {
+    if (!('propertyNameAndValueList' in ctx) ||
+      !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        '$not requires a non-empty document'
+      );
+    }
+    const val = ctx.propertyNameAndValueList()
+      .propertyAssignment()[0]
+      .singleExpression();
+    const innerop = this.visit(ctx.propertyNameAndValueList()
+      .propertyAssignment()[0]
+      .propertyName()).substr(1);
+    const inner = this.handleFieldOp(val, innerop, parent);
+    return `${op}(${inner})`;
+  }
+
+  /**
+   * Method for handling an idiomatic $mod.
+   *
+   * { field: { $mod: [arr1, arr2] } } => mod(field, arr1, arr2)
+   *
+   * ctx must be an array of length 2.
+   *
+   * @param {ObjectLiteralExpressionContext} ctx - the ctx of the value of the
+   * $mod field
+   * @param {String} op - the operation, which in this case is "mod"
+   * @param {ObjectLiteralExpressionContext} parent - ctx of parent document.
+   * @return {String}
+   */
+  handlemod(ctx, op, parent) {
+    if (!('elementList' in ctx) ||
+      !ctx.elementList() ||
+      ctx.elementList().singleExpression().length !== 2) {
+      throw new BsonCompilersRuntimeError(
+        '$mod requires an array of 2-elements'
+      );
+    }
+    const parentField = this.visit(parent.parentCtx.parentCtx.propertyName());
+    const inner = ctx.elementList().singleExpression().map((f) => {
+      return this.visit(f);
+    });
+    return `${op}(${doubleQuoteStringify(parentField)}, ${inner.join(', ')})`;
+  }
+
+  /**
+   * Method for handling an idiomatic $regex.
+   *
+   * { field: { $regex: regexstr, $options?: optsstr } } =>
+   * regex(regexstr, optsstr?)
+   *
+   * ctx must be a string
+   *
+   * @param {ObjectLiteralExpressionContext} ctx - the ctx of the value of the
+   * $regex field
+   * @param {String} op - the operation, which in this case is "regex"
+   * @param {ObjectLiteralExpressionContext} parent - ctx of parent document.
+   * @return {String}
+   */
+  handleregex(ctx, op, parent) {
+    const parentField = this.visit(parent.parentCtx.parentCtx.propertyName());
+    const regex = {r: '', o: ''};
+
+    const properties = parent.propertyNameAndValueList().propertyAssignment();
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      if (field === '$regex') {
+        regex.r = this.visit(pair.singleExpression());
+      }
+      if (field === '$options') {
+        regex.o = `, ${this.visit(pair.singleExpression())}`;
+      }
+    });
+    return `${op}(${doubleQuoteStringify(parentField)}, ${regex.r}${regex.o})`;
+  }
+  handleoptions() {
+    return '';
+  }
+
+  /**
+   * Method for handling an idiomatic $where.
+   *
+   * { field: { $where: <function def> } } => where(<function as string>)
+   *
+   * @param {ObjectLiteralExpressionContext} ctx - the ctx of the value of the
+   * $where field
+   * @return {String}
+   */
+  handlewhere(ctx) {
+    const text = ctx.getParent().getText();
+    return `where(${doubleQuoteStringify(text)})`;
+  }
+
+  /**
+   * Method for handling an idiomatic $sort.
+   *
+   * { $sort: { f1: 1, f2: -1, f3: { $meta: 'textScore' } } } =>
+   * sort(ascending(f1), descending(f2), metaTextScore(f3))
+   *
+   * @param {ObjectLiteralExpressionContext} ctx - the ctx of the value of the
+   * @return {string}
+   */
+  handlesort(ctx) {
+    if (!('propertyNameAndValueList' in ctx) ||
+      !ctx.propertyNameAndValueList()) {
+      throw new BsonCompilersRuntimeError(
+        '$sort requires a non-empty document'
+      );
+    }
+    const properties = ctx.propertyNameAndValueList().propertyAssignment();
+    const fields = [];
+    properties.forEach((pair) => {
+      const field = this.visit(pair.propertyName());
+      const original = pair.singleExpression().getText();
+      if (original === '1') {
+        fields.push(`ascending(${doubleQuoteStringify(field)})`);
+      } else if (original === '-1') {
+        fields.push(`descending(${doubleQuoteStringify(field)})`);
+      } else if (original.match(
+          new RegExp(/{(?:'|")?\$meta(?:'|")?:(?:'|")textScore*(?:'|")}/)
+        )) {
+        fields.push(`metaTextScore(${doubleQuoteStringify(field)})`);
+      } else {
+        throw new BsonCompilersRuntimeError(
+          '$sort key ordering must be specified using a number or ' +
+          '{$meta: \'textScore\'}'
+        );
+      }
+    });
+    const res = fields.length > 1 ?
+      `orderBy(${fields.join(', ')})` :
+      fields[0];
+    return `sort(${res})`;
+  }
+
+  handlesample(ctx) {
+    return this.handleSingleSubfield(ctx, 'sample', 'size', true);
+  }
+  handlereplaceRoot(ctx) {
+    return this.handleSingleSubfield(ctx, 'replaceRoot', 'newRoot', false);
+  }
+  handlegraphLookup(ctx) {
+    return this.handleOptionsObject(
+      ctx,
+      'graphLookup',
+      ['from', 'startWith', 'connectFromField', 'connectToField', 'as'],
+      ['maxDepth', 'depthField', 'restrictSearchWithMatch'],
+      { graphLookup: 'GraphLookupOptions' }
+    );
+  }
+  handlelookup(ctx) {
+    return this.handleOptionsObject(
+      ctx,
+      'lookup',
+      ['from', 'localField', 'foreignField', 'as'],
+      [],
+      { lookup: 'LookupOptions' }
+    );
+  }
+  handlebucket(ctx) {
+    return this.handleOptionsObject(
+      ctx,
+      'bucket',
+      ['groupBy', 'boundaries'],
+      ['default', 'output'],
+      {
+        bucket: 'BucketOptions',
+        default: (k) => { return `.defaultBucket(${k})`; }
+      }
+    );
+  }
+  handlebucketAuto(ctx) {
+    return this.handleOptionsObject(
+      ctx,
+      'bucketAuto',
+      ['groupBy', 'buckets'],
+      ['granularity', 'output'],
+      {
+        bucketAuto: 'BucketAutoOptions',
+        granularity: (k) => {
+          return `.granularity(BucketGranularity.fromString(${k}))`;
+        }
+      }
+    );
+  }
+  handletext(ctx) {
+    return this.handleOptionsObject(
+      ctx,
+      'text',
+      ['$search'],
+      ['$language', '$caseSensitive', '$diacriticSensitive'],
+      {
+        text: 'TextSearchOptions',
+        $language: (k) => { return `.language(${k})`; },
+        $caseSensitive: (k) => { return `.caseSensitive(${k})`; },
+        $diacriticSensitive: (k) => { return `.diacriticSensitive(${k})`; }
+      }
+    );
+  }
+  handleunwind(ctx) {
+    const value = this.visit(ctx.parentCtx);
+    if (ctx.parentCtx.type.id === '_string') {
+      return `unwind(${value})`;
+    }
+    return this.handleOptionsObject(
+      ctx,
+      'unwind',
+      ['path'],
+      ['includeArrayIndex', 'preserveNullAndEmptyArrays'],
+      { unwind: 'UnwindOptions' }
+    );
+  }
+  handlegroup(ctx) {
+    return this.handleMultipleArgs(ctx, 'group', ['_id'], (f, v) => {
+      return v;
+    }, true);
+  }
+  handlefacet(ctx) {
+    return this.handleMultipleArgs(ctx, 'facet', [], (f, v) => {
+      return `new Facet(${doubleQuoteStringify(f)}, ${v})`;
+    }, true);
+  }
+  handleaddFields(ctx) {
+    return this.handleMultipleArgs(ctx, 'addFields', [], (f, v) => {
+      return `new Field(${doubleQuoteStringify(f)}, ${v})`;
+    }, false);
+  }
 };

--- a/index.js
+++ b/index.js
@@ -62,15 +62,18 @@ const getCompiler = (visitor, generator, symbols) => {
     Types: Object.assign({}, doc.BasicTypes, doc.BsonTypes, doc.JSTypes),
     Syntax: doc.Syntax
   });
-  return (input) => {
+  return (input, idiomatic) => {
     try {
       const tree = loadTree(input);
+      compiler.idiomatic = idiomatic | compiler.idiomatic;
       return compiler.start(tree);
     } catch (e) {
       if (e.code && e.code.includes('BSONCOMPILERS')) {
         throw e;
       }
       throw new BsonCompilersInternalError(e.message, e);
+    } finally {
+      compiler.idiomatic = false;
     }
   };
 };

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ const getCompiler = (visitor, generator, symbols) => {
   return (input, idiomatic) => {
     try {
       const tree = loadTree(input);
-      compiler.idiomatic = idiomatic | compiler.idiomatic;
+      compiler.idiomatic = idiomatic === undefined ?
+        compiler.idiomatic :
+        idiomatic;
       return compiler.start(tree);
     } catch (e) {
       if (e.code && e.code.includes('BSONCOMPILERS')) {

--- a/test/idiomatic-error.test.js
+++ b/test/idiomatic-error.test.js
@@ -183,6 +183,12 @@ const errors = {
       input: '{$addFields: 1}',
       error: BsonCompilersRuntimeError
     }
+  ],
+  shape_error: [
+    {
+      input: '{$sum: 1}',
+      error: BsonCompilersRuntimeError
+    }
   ]
 };
 

--- a/test/idiomatic-error.test.js
+++ b/test/idiomatic-error.test.js
@@ -1,0 +1,202 @@
+const chai = require('chai');
+const expect = chai.expect;
+const compiler = require('..');
+const {
+  BsonCompilersRuntimeError
+} = require('../helper/error');
+
+const errors = {
+  type_error: [
+    {
+      input: '{$project: "invalid"}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$project: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$not: "1"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$mod: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$mod: [1]}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$mod: {}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$sort: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$sort: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$sort: {x: 1, y: "not 1/-1"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$sort: {x: 1, y: {}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$sort: {x: 1, y: {$meta: 1}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$project: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$project: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$sample: {}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$sample: {notSize: 1}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$sample: {size: 10, other: 1}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$replaceRoot: {}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$replaceRoot: {notNewRoot: 1}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{x: {$replaceRoot: {newRoot: 10, other: 1}}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$graphLookup: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$graphLookup: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$graphLookup: {from: "x"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{ $graphLookup: {from: "collection", startWith: "$expr", connectFromField: "fromF", connectToField: "toF", as: "asF", extra: 1} }',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$lookup: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$lookup: {from: "x"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{ $lookup: { from: "fromColl", localField: "localF", foreignField: "foreignF", as: "outputF", extra: 1} }',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucket: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucket: {groupBy: "x"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucket: {groupBy: "x", boundaries: 1, extra: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucketAuto: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucketAuto: {groupBy: "x"}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$bucketAuto: {groupBy: "x", buckets: 1, extra: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$text: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$text: {$search: "x", extra: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$unwind: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$unwind: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$unwind: {path: "x", extra: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$group: {x: 1}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$group: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$group: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$facet: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$facet: 1}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$addFields: {}}',
+      error: BsonCompilersRuntimeError
+    },
+    {
+      input: '{$addFields: 1}',
+      error: BsonCompilersRuntimeError
+    }
+  ]
+};
+
+
+describe('Java Builders', () => {
+  describe('handles errors', () => {
+    for (const key of Object.keys(errors)) {
+      describe(`${key}`, () => {
+        for (const test of errors[key]) {
+          it(`${test.input} throws expected error`, () => {
+            expect(()=>{compiler.javascript.java(test.input, true);}).to.throw(test.error);
+          });
+        }
+      });
+    }
+  });
+});

--- a/test/idiomatic.test.js
+++ b/test/idiomatic.test.js
@@ -1,0 +1,636 @@
+const chai = require('chai');
+const expect = chai.expect;
+const compiler = require('..');
+
+const filterOperators = {
+  unknown_op: [
+    {
+      input: '{$notAnOp: {x: 1}}',
+      output: 'eq("$notAnOp", eq("x", 1L))'
+    }
+  ],
+  eq: [
+    {
+      input: '{x: {y: {z: 1}}}',
+      output: 'eq("x", eq("y", eq("z", 1L)))'
+    },
+    {
+      input: '{x: {$eq: {y: {z: 1}}}}',
+      output: 'eq("x", eq("y", eq("z", 1L)))'
+    }
+  ],
+  gt: [
+    {
+      input: '{x: {$gt: 1}}',
+      output: 'gt("x", 1L)'
+    }
+  ],
+  lt: [
+    {
+      input: '{x: {$lt: 1}}',
+      output: 'lt("x", 1L)'
+    }
+  ],
+  gte: [
+    {
+      input: '{x: {$gte: 1}}',
+      output: 'gte("x", 1L)'
+    }
+  ],
+  lte: [
+    {
+      input: '{x: {$lte: 1}}',
+      output: 'lte("x", 1L)'
+    }
+  ],
+  ne: [
+    {
+      input: '{x: {$ne: 1}}',
+      output: 'ne("x", 1L)'
+    }
+  ],
+  in: [
+    {
+      input: '{x: {$in: [1]}}',
+      output: 'in("x", Arrays.asList(1L))'
+    },
+    {
+      input: '{x: {$in: [1, 2]}}',
+      output: 'in("x", Arrays.asList(1L, 2L))'
+    }
+  ],
+  nin: [
+    {
+      input: '{x: {$nin: [1]}}',
+      output: 'nin("x", Arrays.asList(1L))'
+    },
+    {
+      input: '{x: {$nin: [1, 2]}}',
+      output: 'nin("x", Arrays.asList(1L, 2L))'
+    }
+  ],
+  and: [
+    {
+      input: '{x: 1, y: 2}',
+      output: 'and(eq("x", 1L), eq("y", 2L))'
+    }
+  ],
+  or: [
+    {
+      input: '{$or: [{x: 1}, {z: 2}, {e: 1}]}',
+      output: 'or(Arrays.asList(eq("x", 1L), eq("z", 2L), eq("e", 1L)))'
+    }
+  ],
+  not: [
+    {
+      input: '{x: {$not: {$eq: 1}}}',
+      output: 'not(eq("x", 1L))'
+    },
+    {
+      input: '{x: {$not: {$exists: [1, 2]} }  }',
+      output: 'not(exists("x", Arrays.asList(1L, 2L)))'
+    }
+  ],
+  nor: [
+    {
+      input: '{$nor: [{x: 1}, {z: 2}, {e: 1}]}',
+      output: 'nor(Arrays.asList(eq("x", 1L), eq("z", 2L), eq("e", 1L)))'
+    }
+  ],
+  all: [
+    {
+      input: '{x: {$all: ["v1", "v2", "v3"]}}',
+      output: 'all("x", Arrays.asList("v1", "v2", "v3"))'
+    }
+  ],
+  bitsAllSet: [
+    {
+      input: '{x: {$bitsAllSet: 100}}',
+      output: 'bitsAllSet("x", 100L)'
+    }
+  ],
+  bitsAllClear: [
+    {
+      input: '{x: {$bitsAllClear: 100}}',
+      output: 'bitsAllClear("x", 100L)'
+    }
+  ],
+  bitsAnySet: [
+    {
+      input: '{x: {$bitsAnySet: 100}}',
+      output: 'bitsAnySet("x", 100L)'
+    }
+  ],
+  bitsAnyClear: [
+    {
+      input: '{x: {$bitsAnyClear: 100}}',
+      output: 'bitsAnyClear("x", 100L)'
+    }
+  ],
+  elemMatch: [
+    {
+      input: '{x: {$elemMatch: {x: 1, y: 2}}}',
+      output: 'elemMatch("x", and(eq("x", 1L), eq("y", 2L)))'
+    }
+  ],
+  size: [
+    {
+      input: '{x: {$size: 1}}',
+      output: 'size("x", 1L)'
+    }
+  ],
+  exists: [
+    {
+      input: '{x: {$exists: true}}',
+      output: 'exists("x", true)'
+    },
+    {
+      input: '{x: {$exists: false}}',
+      output: 'exists("x", false)'
+    }
+  ],
+  type: [
+    {
+      input: '{x: {$type: "number"} }',
+      output: 'type("x", "number")'
+    }
+  ],
+  mod: [
+    {
+      input: '{x: {$mod: [10, 2]}}',
+      output: 'mod("x", 10L, 2L)'
+    }
+  ],
+  regex: [
+    {
+      input: '{x: {$regex: "abc"}}',
+      output: 'regex("x", "abc")'
+    },
+    {
+      input: '{x: {$regex: "abc", $options: "g"}}',
+      output: 'regex("x", "abc", "g")'
+    }
+  ],
+  text: [
+    {
+      input: '{x: {$text: {$search: "searchstring"}}}',
+      output: 'eq("x", text("searchstring"))'
+    },
+    {
+      input: `{x: {$text: {
+        $search: "searchstring",
+        $language: "lang",
+        $caseSensitive: true,
+        $diacriticSensitive: true}}}`,
+      output: 'eq("x", text("searchstring", new TextSearchOptions().language("lang").caseSensitive(true).diacriticSensitive(true)))'
+    }
+  ],
+  where: [
+    {
+      input: '{x: {$where: function() { $x === true }}}',
+      output: 'eq("x", where("function(){$x===true}"))'
+    }
+  ],
+  // TODO: geo ops
+  geoWithin: [
+  ],
+  geoWithinBox: [
+  ],
+  geoWithinPolygon: [
+  ],
+  geoWithinCenter: [
+  ],
+  geoWithinCenterSphere: [
+  ],
+  geoWithinIntersects: [
+  ],
+  near: [
+  ],
+  nearSphere: [
+  ],
+  geoJSONclasses: [
+  ]
+};
+
+const accumulatorOperators = {
+  sum: [
+    {
+      input: '{x: {$sum: 1}}',
+      output: 'sum("x", 1L)'
+    }
+  ],
+  avg: [
+    {
+      input: '{x: {$avg: 1}}',
+      output: 'avg("x", 1L)'
+    }
+  ],
+  first: [
+    {
+      input: '{x: {$first: 1}}',
+      output: 'first("x", 1L)'
+    }
+  ],
+  last: [
+    {
+      input: '{x: {$last: 1}}',
+      output: 'last("x", 1L)'
+    }
+  ],
+  max: [
+    {
+      input: '{x: {$max: 1}}',
+      output: 'max("x", 1L)'
+    }
+  ],
+  min: [
+    {
+      input: '{x: {$min: 1}}',
+      output: 'min("x", 1L)'
+    }
+  ],
+  push: [
+    {
+      input: '{x: {$push: 1}}',
+      output: 'push("x", 1L)'
+    }
+  ],
+  addToSet: [
+    {
+      input: '{x: {$addToSet: 1}}',
+      output: 'addToSet("x", 1L)'
+    }
+  ],
+  stdDevPop: [
+    {
+      input: '{x: {$stdDevPop: 1}}',
+      output: 'stdDevPop("x", 1L)'
+    }
+  ],
+  stdDevSamp: [
+    {
+      input: '{x: {$stdDevSamp: 1}}',
+      output: 'stdDevSamp("x", 1L)'
+    }
+  ]
+};
+
+const aggOperators = {
+  match: [
+    {
+      input: '{ $match: {x: 1} }',
+      output: 'match(eq("x", 1L))'
+    },
+    {
+      input: '{ $match: {x: 1, y: 2} }',
+      output: 'match(and(eq("x", 1L), eq("y", 2L)))'
+    }
+  ],
+  project: [
+    {
+      input: '{ $project: { z: 1 } }',
+      output: 'project(include("z"))'
+    },
+    {
+      input: '{ $project: { z: 1 , y: true} }',
+      output: 'project(include("z", "y"))'
+    },
+    {
+      input: '{ $project: { z: false } }',
+      output: 'project(exclude("z"))'
+    },
+    {
+      input: '{ $project: { z: 1, y: false } }',
+      output: 'project(fields(include("z"), exclude("y")))'
+    },
+    {
+      input: '{ $project: { _id: 0 } }',
+      output: 'project(excludeId())'
+    },
+    {
+      input: '{ $project: { x: true, y: false, _id: 0 } }',
+      output: 'project(fields(include("x"), exclude("y"), excludeId()))'
+    },
+    {
+      input: '{ $project: { z: { a: 9 } } }',
+      output: 'project(computed("z", eq("a", 9L)))'
+    },
+    {
+      input: '{ $project: { z: "$z"} }',
+      output: 'project(computed("z", "$z"))'
+    }
+    // TODO: ElemMatch + Slice
+  ],
+  sample: [
+    {
+      input: '{ $sample: { size: 1 } }',
+      output: 'sample(1L)'
+    }
+  ],
+  sort: [
+    {
+      input: '{ $sort: { x: 1, y: -1 } }',
+      output: 'sort(orderBy(ascending("x"), descending("y")))'
+    },
+    {
+      input: '{ $sort: { x: 1, y: -1, z: { $meta: "textScore" } } }',
+      output: 'sort(orderBy(ascending("x"), descending("y"), metaTextScore("z")))'
+    },
+    {
+      input: '{ $sort: { x: 1, y: -1, z: { \'$meta\': "textScore" } } }',
+      output: 'sort(orderBy(ascending("x"), descending("y"), metaTextScore("z")))'
+    },
+    {
+      input: '{ $sort: { x: 1, y: -1, z: { \"$meta\": "textScore" } } }',
+      output: 'sort(orderBy(ascending("x"), descending("y"), metaTextScore("z")))'
+    },
+    {
+      input: '{ $sort: { x: 1, y: -1, z: { $meta: \'textScore\' } } }',
+      output: 'sort(orderBy(ascending("x"), descending("y"), metaTextScore("z")))'
+    }
+  ],
+  skip: [
+    {
+      input: '{ $skip: 10 }',
+      output: 'skip(10L)'
+    }
+  ],
+  limit: [
+    {
+      input: '{ $limit: 1 }',
+      output: 'limit(1L)'
+    }
+  ],
+  lookup: [
+    {
+      input: `{ $lookup: {
+       from: 'fromColl',
+       localField: 'localF',
+       foreignField: 'foreignF',
+       as: 'outputF'
+     } }`,
+      output: 'lookup("fromColl", "localF", "foreignF", "outputF")'
+    }
+  ],
+  group: [
+    {
+      input: '{ $group: { _id: "idField" } }',
+      output: 'group("idField")'
+    },
+    {
+      input: '{ $group: { _id: "idField", total: { $sum: "$idField" }, average: { $avg: "$idField" } } }',
+      output: 'group("idField", sum("total", "$idField"), avg("average", "$idField"))'
+    }
+  ],
+  unwind: [
+    {
+      input: '{ $unwind: "$field" }',
+      output: 'unwind("$field")'
+    },
+    {
+      input: '{ $unwind: { path: "$field"} }',
+      output: 'unwind("$field")'
+    },
+    {
+      input: '{ $unwind: { path: "$field", includeArrayIndex: "element" } }',
+      output: 'unwind("$field", new UnwindOptions().includeArrayIndex("element"))'
+    },
+    {
+      input: '{ $unwind: { path: "$field", includeArrayIndex: "element", preserveNullAndEmptyArrays: true } }',
+      output: 'unwind("$field", new UnwindOptions().includeArrayIndex("element").preserveNullAndEmptyArrays(true))'
+    }
+  ],
+  out: [
+    {
+      input: '{ $out: "coll" }',
+      output: 'out("coll")'
+    }
+  ],
+  graphLookup: [
+    {
+      input: `{ $graphLookup: {
+      from: "collection",
+      startWith: "$expr",
+      connectFromField: "fromF",
+      connectToField: "toF",
+      as: "asF" } }`,
+      output: 'graphLookup("collection", "$expr", "fromF", "toF", "asF")'
+    },
+    {
+      input: `{ $graphLookup: {
+      from: "collection",
+      startWith: "$expr",
+      connectFromField: "fromF",
+      connectToField: "toF",
+      as: "asF",
+      maxDepth: 10,
+      depthField: "depthF",
+      restrictSearchWithMatch: { x: 1 } } }`,
+      output: 'graphLookup("collection", "$expr", "fromF", "toF", "asF", new GraphLookupOptions().maxDepth(10L).depthField("depthF").restrictSearchWithMatch(eq("x", 1L)))'
+    }
+  ],
+  sortByCount: [
+    {
+      input: '{ $sortByCount: "$expr" }',
+      output: 'sortByCount("$expr")'
+    },
+    {
+      input: '{ $sortByCount: { "$floor": "$x" } }',
+      output: 'sortByCount(eq("$floor", "$x"))'
+    }
+  ],
+  replaceRoot: [
+    {
+      input: '{ $replaceRoot: { newRoot: { x: "newDoc" } } }',
+      output: 'replaceRoot(new Document("x", "newDoc"))'
+    }
+  ],
+  addFields: [
+    {
+      input: '{ $addFields: { x: 1, y: {z: 2} } }',
+      output: 'addFields(new Field("x", 1L), new Field("y", new Document("z", 2L)))'
+    }
+  ],
+  count: [
+    {
+      input: '{ $count: "field" }',
+      output: 'count("field")'
+    }
+  ],
+  bucket: [
+    {
+      input: `{ $bucket: {
+      groupBy: '$expr',
+      boundaries: [ 0, 10, 20 ],
+      } }`,
+      output: 'bucket("$expr", Arrays.asList(0L, 10L, 20L))'
+    },
+    {
+      input: `{ $bucket: {
+      groupBy: '$expr',
+      boundaries: [ 0, 10, 20 ],
+      output: {
+         "output1": { $sum: 1 },
+      } } }`,
+      output: 'bucket("$expr", Arrays.asList(0L, 10L, 20L), new BucketOptions().output(sum("output1", 1L)))'
+    },
+    {
+      input: `{ $bucket: {
+      groupBy: '$expr',
+      boundaries: [ 0, 10, 20 ],
+      default: "default",
+      output: {
+         "output1": { $sum: 1 },
+      } } }`,
+      output: 'bucket("$expr", Arrays.asList(0L, 10L, 20L), new BucketOptions().defaultBucket("default").output(sum("output1", 1L)))'
+    }
+  ],
+  bucketAuto: [
+    {
+      input: `{ $bucketAuto: {
+      groupBy: "$expr",
+      buckets: 88 } }`,
+      output: 'bucketAuto("$expr", 88L)'
+    },
+    {
+      input: `{ $bucketAuto: {
+      groupBy: "$expr",
+      buckets: 88,
+      output: {
+         "output1": { $sum: 1 },
+      },
+      granularity: "POWERSOF2" }}`,
+      output: 'bucketAuto("$expr", 88L, new BucketAutoOptions().output(sum("output1", 1L)).granularity(BucketGranularity.fromString("POWERSOF2")))'
+    }
+  ],
+  facet: [
+    {
+      input: '{ $facet: { output1: [{ $match: {x: 1} }] } }',
+      output: 'facet(new Facet("output1", Arrays.asList(match(eq("x", 1L)))))'
+    },
+    {
+      input: '{ $facet: { output1: [{ $match: {x: 1} }], output2: [{$sample: {size: 10} }] } }',
+      output: 'facet(new Facet("output1", Arrays.asList(match(eq("x", 1L)))), new Facet("output2", Arrays.asList(sample(10L))))'
+    }
+  ],
+  // These agg ops don't have builders
+  collStats: [
+    {
+      input: '{ $collStats: { latencyStats: { histograms: true } } }',
+      output: 'eq("$collStats", eq("latencyStats", eq("histograms", true)))'
+    }
+  ],
+  currentOp: [
+    {
+      input: '{ $currentOp : { allUsers: true, idleSessions: true } }',
+      output: 'eq("$currentOp", and(eq("allUsers", true), eq("idleSessions", true)))'
+    }
+  ],
+  geoNear: [
+    {
+      input: '',
+      output: ''
+    }
+  ],
+  indexStats: [
+    {
+      input: '{ $indexStats: { } }',
+      output: 'eq("$indexStats", new Document())'
+    }
+  ],
+  listLocalSessions: [
+    {
+      input: '{ $listLocalSessions: { allUsers: true } }',
+      output: 'eq("$listLocalSessions", eq("allUsers", true))'
+    }
+  ],
+  listSessions: [
+    {
+      input: '{ $listSessions: { allUsers: true } }',
+      output: 'eq("$listSessions", eq("allUsers", true))'
+    }
+  ],
+  redact: [
+    {
+      input: '{\n' +
+      '      $redact: {\n' +
+      '        $cond: {\n' +
+      '          if: { $eq: [ "$level", 5 ] },\n' +
+      '          then: "$$PRUNE",\n' +
+      '          else: "$$DESCEND"\n' +
+      '        }\n' +
+      '      }\n' +
+      '    }',
+      output: 'eq("$redact", eq("$cond", and(eq("if", Arrays.asList("$level", 5L)), eq("then", "$$PRUNE"), eq("else", "$$DESCEND"))))'
+    }
+  ]
+};
+
+describe('Java Builders', () => {
+  describe('The default', () => {
+    it('is non-idiomatic', () => {
+      expect(compiler.javascript.java('{x: 1}')).to.equal(
+        'new Document("x", 1L)'
+      );
+    });
+  });
+  describe('non-operator fields', () => {
+    it('single non-operator field', () => {
+      expect(compiler.javascript.java('{x: 1}', true)).to.equal('eq("x", 1L)');
+    });
+    it('two non-operator fields uses and(...)', () => {
+      expect(compiler.javascript.java('{x: 1, y: 2}', true)).to.equal(
+        'and(eq("x", 1L), eq("y", 2L))');
+    });
+    it('five non-operator fields uses and(...)', () => {
+      expect(compiler.javascript.java('{x: 1, y: 2, z: 3, q: 4, r: 5}', true)).to.equal(
+        'and(eq("x", 1L), eq("y", 2L), eq("z", 3L), eq("q", 4L), eq("r", 5L))'
+      );
+    });
+  });
+  describe('non-operator nested fields', () => {
+    it('single nested document', () => {
+      expect(compiler.javascript.java('{x: {y: 2}}', true)).to.equal(
+        'eq("x", eq("y", 2L))'
+      );
+    });
+    it('multiple nested documents', () => {
+      expect(compiler.javascript.java('{x: {y: 2}, z: {q: {r: 5}}}', true)).to.equal(
+        'and(eq("x", eq("y", 2L)), eq("z", eq("q", eq("r", 5L))))'
+      );
+    });
+  });
+  describe('agg operators', () => {
+    for (const key of Object.keys(aggOperators)) {
+      describe(`${key}`, () => {
+        for (const test of aggOperators[key]) {
+          it(`${test.input} equals expected`, () => {
+            expect(compiler.javascript.java(test.input, true)).to.equal(test.output);
+          });
+        }
+      });
+    }
+  });
+  describe('filter operators', () => {
+    for (const key of Object.keys(filterOperators)) {
+      describe(`${key}`, () => {
+        for (const test of filterOperators[key]) {
+          it(`${test.input} equals expected`, () => {
+            expect(compiler.javascript.java(test.input, true)).to.equal(test.output);
+          });
+        }
+      });
+    }
+  });
+  describe('accumulator operators', () => {
+    for (const key of Object.keys(accumulatorOperators)) {
+      describe(`${key}`, () => {
+        for (const test of accumulatorOperators[key]) {
+          it(`${test.input} equals expected`, () => {
+            expect(compiler.javascript.java(test.input, true)).to.equal(test.output);
+          });
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
Adds support for generating java code using the [builders classes](http://mongodb.github.io/mongo-java-driver/3.6/builders/).

The API has changed in that it now takes an optional second argument, "idiomatic", which if true will generate java using the builders. TODO: do we want to automatically generate with builders, or documents?

The other set of changes are within the Java Generator, now each operator has a method that will generate the correct builder. I added a lot of comments so hopefully the code is clear.

When this is merged, we'll be done with "idiomatic" java!

Please take a look!